### PR TITLE
Dump config

### DIFF
--- a/BoxCLI/CommandUtilities/Globalization/Models/SubCommandNames.cs
+++ b/BoxCLI/CommandUtilities/Globalization/Models/SubCommandNames.cs
@@ -55,5 +55,6 @@ namespace BoxCLI.CommandUtilities.Globalization.Models
         public string ListForGroup { get; set; } = "list-for-group";
         public string UpdatePrivateKeyPath { get; set; } = "update-private-key-path";
         public string UpdateConfigFilePath { get; set; } = "update-config-file-path";
+        public string DumpConfig { get; set; } = "dump-config";
     }
 }

--- a/BoxCLI/Commands/ConfigureSubCommands/ConfigureEnvironmentsSubCommands/ConfigureEnvironmentsCommand.cs
+++ b/BoxCLI/Commands/ConfigureSubCommands/ConfigureEnvironmentsSubCommands/ConfigureEnvironmentsCommand.cs
@@ -28,6 +28,7 @@ namespace BoxCLI.Commands.ConfigureSubCommands.ConfigureEnvironmentsSubCommands
             command.Command(_names.SubCommandNames.Delete, _subCommands.CreateSubCommand(_names.SubCommandNames.Delete).Configure);
             command.Command(_names.SubCommandNames.UpdatePrivateKeyPath, _subCommands.CreateSubCommand(_names.SubCommandNames.UpdatePrivateKeyPath).Configure);
             command.Command(_names.SubCommandNames.UpdateConfigFilePath, _subCommands.CreateSubCommand(_names.SubCommandNames.UpdateConfigFilePath).Configure);
+            command.Command(_names.SubCommandNames.DumpConfig, _subCommands.CreateSubCommand(_names.SubCommandNames.DumpConfig).Configure);
             base.Configure(command);
         }
         protected override int Execute()

--- a/BoxCLI/Commands/ConfigureSubCommands/ConfigureEnvironmentsSubCommands/ConfigureEnvironmentsDumpConfigCommand.cs
+++ b/BoxCLI/Commands/ConfigureSubCommands/ConfigureEnvironmentsSubCommands/ConfigureEnvironmentsDumpConfigCommand.cs
@@ -19,7 +19,7 @@ namespace BoxCLI.Commands.ConfigureSubCommands.ConfigureEnvironmentsSubCommands
             command.Description = "Dump the current environment config information as one string; meant for copying value into environment variable or property setting.";
 
             _escapeQuotes = command.Option("--escape-quotes",
-                           "Add escape character for all double quotes.  Typically used when copying value into a JSON config file.",
+                           "Add escape character for all double quotes.  Typically used when copying the output into a JSON config file.",
                            CommandOptionType.NoValue);
 
             command.OnExecute(() =>

--- a/BoxCLI/Commands/ConfigureSubCommands/ConfigureEnvironmentsSubCommands/ConfigureEnvironmentsDumpConfigCommand.cs
+++ b/BoxCLI/Commands/ConfigureSubCommands/ConfigureEnvironmentsSubCommands/ConfigureEnvironmentsDumpConfigCommand.cs
@@ -16,7 +16,7 @@ namespace BoxCLI.Commands.ConfigureSubCommands.ConfigureEnvironmentsSubCommands
 
         public override void Configure(CommandLineApplication command)
         {
-            command.Description = "Dump the current environment config information as one string; meant for copying value into environment variable or property setting.";
+            command.Description = "Dump the current environment config information as one string; typically used for copying the config info into an environment variable or property setting.";
 
             _escapeQuotes = command.Option("--escape-quotes",
                            "Add escape character for all double quotes.  Typically used when copying the output into a JSON config file.",

--- a/BoxCLI/Commands/ConfigureSubCommands/ConfigureEnvironmentsSubCommands/ConfigureEnvironmentsDumpConfigCommand.cs
+++ b/BoxCLI/Commands/ConfigureSubCommands/ConfigureEnvironmentsSubCommands/ConfigureEnvironmentsDumpConfigCommand.cs
@@ -1,0 +1,42 @@
+﻿using BoxCLI.BoxHome;
+using BoxCLI.CommandUtilities;
+using Microsoft.Extensions.CommandLineUtils;
+using System.IO;
+
+namespace BoxCLI.Commands.ConfigureSubCommands.ConfigureEnvironmentsSubCommands
+{
+    public class ConfigureEnvironmentsDumpConfigCommand : ConfigureEnvironmentsSubCommandBase
+    {
+        public ConfigureEnvironmentsDumpConfigCommand(IBoxHome boxHome) : base(boxHome)
+        {
+        }
+
+        public override void Configure(CommandLineApplication command)
+        {
+            command.Description = "Dump the current environment config information as one string; meant for copying value into environment variable or property setting.";
+            command.OnExecute(() =>
+            {
+                return this.Execute();
+            });
+            base.Configure(command);
+        }
+
+        protected override int Execute()
+        {
+            this.RunDumpConfig();
+            return base.Execute();
+        }
+
+        protected virtual void RunDumpConfig()
+        {
+            var defaultEnv = _environments.GetDefaultEnvironment();
+            var path = defaultEnv.BoxConfigFilePath;
+            var configInfo = File.ReadAllText(path);
+
+
+
+            Reporter.WriteInformation($"Dumping config file '{configInfo}'");
+        }
+
+    }
+}

--- a/BoxCLI/Commands/ConfigureSubCommands/ConfigureEnvironmentsSubCommands/ConfigureEnvironmentsDumpConfigCommand.cs
+++ b/BoxCLI/Commands/ConfigureSubCommands/ConfigureEnvironmentsSubCommands/ConfigureEnvironmentsDumpConfigCommand.cs
@@ -45,7 +45,7 @@ namespace BoxCLI.Commands.ConfigureSubCommands.ConfigureEnvironmentsSubCommands
                 return;
             }
             var configInfo = File.ReadAllText(path);
-            configInfo = Regex.Replace(configInfo, @"\r\n?|\n|  *", string.Empty);
+            configInfo = Regex.Replace(configInfo, @"\r\n?|\n| {2,}", string.Empty);
 
             if (_escapeQuotes.HasValue())
             {

--- a/BoxCLI/Commands/ConfigureSubCommands/ConfigureEnvironmentsSubCommands/ConfigureEnvironmentsSubCommandFactory.cs
+++ b/BoxCLI/Commands/ConfigureSubCommands/ConfigureEnvironmentsSubCommands/ConfigureEnvironmentsSubCommandFactory.cs
@@ -64,6 +64,10 @@ namespace BoxCLI.Commands.ConfigureSubCommands.ConfigureEnvironmentsSubCommands
 			{
 				return new ConfigureEnvironmentsUpdateConfigFilePathCommand(_boxHome);
 			}
+            else if(commandName == _names.SubCommandNames.DumpConfig)
+            {
+                return new ConfigureEnvironmentsDumpConfigCommand(_boxHome);
+            }
             else
             {
                 throw new Exception("Command not registered.");


### PR DESCRIPTION
adds the ability to dump the Box config file as a single string, optionally with escaped quotes, in order to copy the value to an environment variable or config property (for example, in AWS or Azure).