### PR TITLE
Added optional --save-to-file-path for downloads, bumped version to 1…

### DIFF
--- a/BoxCLI/BoxCLIInfo.cs
+++ b/BoxCLI/BoxCLIInfo.cs
@@ -4,6 +4,6 @@ namespace BoxCLI
     {
         public const string ProductTitle = "Box CLI";
 
-        public const string Version = "1.3.0";
+        public const string Version = "1.3.1";
     }
 }

--- a/BoxCLI/CommandUtilities/CommandOptions/FilePathOption.cs
+++ b/BoxCLI/CommandUtilities/CommandOptions/FilePathOption.cs
@@ -5,6 +5,6 @@ namespace BoxCLI.CommandUtilities.CommandOptions
     public static class FilePathOption
     {
         public static CommandOption ConfigureOption(CommandLineApplication command)
-            => command.Option("--save-to-file-path <FILEPATH>", "Override default file path to save report", CommandOptionType.SingleValue);
+            => command.Option("--save-to-file-path <FILEPATH>", "Override default file path", CommandOptionType.SingleValue);
     }
 }

--- a/BoxCLI/Commands/FileSubCommand/FileDownloadCommand.cs
+++ b/BoxCLI/Commands/FileSubCommand/FileDownloadCommand.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -17,6 +18,7 @@ namespace BoxCLI.Commands.FileSubCommand
         private CommandArgument _fileId;
         private CommandOption _multiId;
         private CommandOption _bulkPath;
+        private CommandOption _filePath;
         private CommandLineApplication _app;
         public FileDownloadCommand(IBoxPlatformServiceBuilder boxPlatformBuilder, IBoxHome boxHome, LocalizedStringsResource names)
             : base(boxPlatformBuilder, boxHome, names)
@@ -32,6 +34,7 @@ namespace BoxCLI.Commands.FileSubCommand
                                "Download multiple files with a comma separated list of IDs.",
                                CommandOptionType.NoValue);
             _bulkPath = BulkFilePathOption.ConfigureOption(command);
+            _filePath = FilePathOption.ConfigureOption(command);
             command.OnExecute(async () =>
             {
                 return await this.Execute();
@@ -69,7 +72,7 @@ namespace BoxCLI.Commands.FileSubCommand
                 return;
             }
             base.CheckForFileId(this._fileId.Value, this._app);
-            await base.DownloadFile(this._fileId.Value);
+            await base.DownloadFile(this._fileId.Value, this._filePath.Value());
         }
     }
 }

--- a/BoxCLI/Commands/FileSubCommand/FileSubCommandBase.cs
+++ b/BoxCLI/Commands/FileSubCommand/FileSubCommandBase.cs
@@ -79,7 +79,7 @@ namespace BoxCLI.Commands.FileSubCommand
             return await boxClient.FilesManager.CopyAsync(fileRequest);
         }
 
-        protected async Task DownloadFile(string fileId, string fileVersionId = "")
+        protected async Task DownloadFile(string fileId, string filePath, string fileVersionId = "")
         {
             var boxClient = base.ConfigureBoxClient(oneCallAsUserId: base._asUser.Value(), oneCallWithToken: base._oneUseToken.Value());
             var fileInfo = await boxClient.FilesManager.GetInformationAsync(fileId);
@@ -94,12 +94,12 @@ namespace BoxCLI.Commands.FileSubCommand
                 Reporter.WriteInformation($"Downloading {fileInfo.Name}...");
                 boxFileStream = await boxClient.FilesManager.DownloadStreamAsync(fileId);
             }
-            var downloadPath = base.ConstructDownloadsPath(fileInfo.Name);
-            Reporter.WriteInformation($"Saving to ${downloadPath}");
+            var downloadPath = base.ConstructDownloadsPath(fileInfo.Name, filePath);
+            Reporter.WriteInformation($"Saving to {downloadPath}");
             using (var fileStream = File.Open($"{downloadPath}", FileMode.Create))
             {
                 boxFileStream.CopyTo(fileStream);
-                Reporter.WriteSuccess("Copied file...");
+                Reporter.WriteSuccess("File Sucessfully downloaded");
             }
         }
     }

--- a/BoxCLI/Commands/FileVersionSubCommands/FileVersionDownloadCommand.cs
+++ b/BoxCLI/Commands/FileVersionSubCommands/FileVersionDownloadCommand.cs
@@ -3,6 +3,7 @@ using BoxCLI.BoxHome;
 using BoxCLI.BoxPlatform.Service;
 using BoxCLI.Commands.FileSubCommand;
 using BoxCLI.CommandUtilities.Globalization;
+using BoxCLI.CommandUtilities.CommandOptions;
 using Microsoft.Extensions.CommandLineUtils;
 
 namespace BoxCLI.Commands.FileVersionSubCommands
@@ -11,6 +12,7 @@ namespace BoxCLI.Commands.FileVersionSubCommands
     {
         private CommandArgument _fileId;
         private CommandArgument _fileVersionId;
+        private CommandOption _filePath;
         private CommandLineApplication _app;
         public FileVersionDownloadCommand(IBoxPlatformServiceBuilder boxPlatformBuilder, IBoxHome home, LocalizedStringsResource names)
             : base(boxPlatformBuilder, home, names)
@@ -25,6 +27,7 @@ namespace BoxCLI.Commands.FileVersionSubCommands
                                "Id of file to download");
             _fileVersionId = command.Argument("fileVersionId",
                                "Id of file version to download");
+            _filePath = FilePathOption.ConfigureOption(command);
             command.OnExecute(async () =>
             {
                 return await this.Execute();
@@ -42,7 +45,7 @@ namespace BoxCLI.Commands.FileVersionSubCommands
         {
             base.CheckForFileId(this._fileId.Value, this._app);
             base.CheckForFileVersionId(this._fileVersionId.Value, this._app);
-            await base.DownloadFile(this._fileId.Value, this._fileVersionId.Value);
+            await base.DownloadFile(this._fileId.Value, this._filePath.Value(), this._fileVersionId.Value);
         }
     }
 }


### PR DESCRIPTION
Hi, I found saving downloads always to the downloads directory configured via settings to be not thread safe, if I wanted to use boxcli multiple times for downloading a tree, so I added an optional download parameter to the downloads.

It seems to work, but since there are no unit tests I do not know what kind of side effects this might introduce. I did a search on the affected functions and seemed to have caught all cases, but please review.