### PR TITLE
Fix duplicate execution during bulk input on delegated command

### DIFF
--- a/src/box-command.js
+++ b/src/box-command.js
@@ -398,11 +398,14 @@ class BoxCommand extends Command {
 			// Include flag values from command line first; they'll automatically
 			// be overwritten/combined with later values by the oclif parser
 			Object.keys(this.flags)
+				.filter(flag => flag !== 'bulk-file-path') // Remove the bulk file path flag so we don't recurse!
 				.forEach(flag => this._addFlagToArgv(flag, this.flags[flag]));
 
 			// Include all flag values from bulk input, which will override earlier ones
 			// from the command line
-			bulkData.filter(o => o.type === 'flag')
+			bulkData
+				// Remove the bulk file path flag so we don't recurse!
+				.filter(o => o.type === 'flag' && o.fieldKey !== 'bulk-file-path')
 				.forEach(o => this._addFlagToArgv(o.fieldKey, o.value));
 
 			DEBUG.execute('Executing in bulk mode argv: %O', this.argv);

--- a/test/commands/bulk.test.js
+++ b/test/commands/bulk.test.js
@@ -292,6 +292,51 @@ describe('Bulk', () => {
 				'--token=test'
 			])
 			.it('should ignore CSV keys that do not map to valid args or flags');
+
+		let folderCollabInput = path.join(__dirname, '..', 'fixtures/bulk/folder_collab_input.csv');
+		test
+			.nock(TEST_API_ROOT, api => api
+				.post('/2.0/collaborations', {
+					item: {
+						type: 'folder',
+						id: '11111',
+					},
+					accessible_by: {
+						type: 'user',
+						login: 'mario@example.com',
+					}
+				})
+				.reply(200, {})
+				.post('/2.0/collaborations', {
+					item: {
+						type: 'folder',
+						id: '22222',
+					},
+					accessible_by: {
+						type: 'user',
+						login: 'wario@example.com'
+					}
+				})
+				.reply(200, {})
+				.post('/2.0/collaborations', {
+					item: {
+						type: 'folder',
+						id: '33333',
+					},
+					accessible_by: {
+						type: 'user',
+						login: 'peach@example.com'
+					}
+				})
+				.reply(200, {})
+			)
+			.stdout()
+			.command([
+				'folders:collaborations:add', // @NOTE: This command delegates to collaborations:add
+				`--bulk-file-path=${folderCollabInput}`,
+				'--token=test'
+			])
+			.it('should not run duplicate commands when delegating to another command');
 	});
 
 	describe('JSON Input', () => {

--- a/test/fixtures/bulk/folder_collab_input.csv
+++ b/test/fixtures/bulk/folder_collab_input.csv
@@ -1,0 +1,4 @@
+id,login
+11111,mario@example.com
+22222,wario@example.com
+33333,peach@example.com


### PR DESCRIPTION
Commands that delegate to other commands were passing the bulk
input flag through to the subcommand.  Since the command being
delegated to is executed in a way that includes re-initialization,
this would re-run the entire bulk input again for each entry in
the bulk input file.  To fix this, that flag is now filtered out
when running each command for the bulk input file, to ensure that
no such recursion is possible.