### PR TITLE
Build command docs on separate pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,9 +129,9 @@
 		"test": "nyc mocha \"test/**/*.test.js\"",
 		"posttest": "npm run lint",
 		"lint": "eslint --fix ./src ./test",
-		"prepack": "oclif-dev manifest && oclif-dev readme && npm shrinkwrap && git checkout origin/master -- package-lock.json",
+		"prepack": "oclif-dev manifest && oclif-dev readme --multi && npm shrinkwrap && git checkout origin/master -- package-lock.json",
 		"postpack": "rm -f oclif.manifest.json && rm -f npm-shrinkwrap.json",
-		"version": "oclif-dev readme && git add README.md",
+		"version": "oclif-dev readme --multi && git add README.md && git add docs",
 		"build": "oclif-dev pack:macos && rm -rf tmp/ && oclif-dev pack:win && rm -rf tmp/"
 	}
 }


### PR DESCRIPTION
By default, oclif autogenerates all command documentation into the
README during release.  Since we have a large number of commands,
this results in 5,000+ lines in the README, which seems like too
much for a developer to sort through.  There's an option to instead
write the docs to separate files by topic; this option has been
added to the applicable commands in the release scripts.