### PR TITLE
Add support for restricting folder to enterprise

### DIFF
--- a/src/commands/folders/update.js
+++ b/src/commands/folders/update.js
@@ -14,13 +14,16 @@ class FoldersUpdateCommand extends BoxCommand {
 		if (flags.hasOwnProperty('description')) {
 			updates.description = flags.description;
 		}
-		if (flags['folder-upload-email-access']) {
+		if (flags['upload-email-access']) {
 			updates.folder_upload_email = {
-				access: flags['folder-upload-email-access']
+				access: flags['upload-email-access']
 			};
 		}
 		if (flags.hasOwnProperty('restrict-collaboration')) {
 			updates.can_non_owners_invite = flags['restrict-collaboration'];
+		}
+		if (flags.hasOwnProperty('restrict-to-enterprise')) {
+			updates.is_collaboration_restricted_to_enterprise = flags['restrict-to-enterprise'];
 		}
 		if (flags.tags) {
 			updates.tags = (flags.tags).split(',');
@@ -59,6 +62,10 @@ FoldersUpdateCommand.flags = {
 	'restrict-collaboration': flags.boolean({
 		description: 'Restrict collaboration so only owners can invite new collaborators',
 		allowNo: true
+	}),
+	'restrict-to-enterprise': flags.boolean({
+		description: 'Restrict collaboration so only users in the folder owner\'s enterprise can be added',
+		allowNo: true,
 	}),
 	etag: flags.string({ description: 'Only apply updates if the etag value matches' }),
 };

--- a/test/commands/folders.test.js
+++ b/test/commands/folders.test.js
@@ -1283,7 +1283,52 @@ describe('Folders', () => {
 				assert.equal(ctx.stderr, `${msg}${os.EOL}`);
 			});
 
-		// @TODO(2018-08-21): Add tests for other flags
+		leche.withData({
+			'restrict collaboration flag': [
+				'--restrict-collaboration',
+				{can_non_owners_invite: true}
+			],
+			'no restrict collaboration flag': [
+				'--no-restrict-collaboration',
+				{can_non_owners_invite: false}
+			],
+			'restrict to enterprise flag': [
+				'--restrict-to-enterprise',
+				{is_collaboration_restricted_to_enterprise: true}
+			],
+			'no restrict to enterprise flag': [
+				'--no-restrict-to-enterprise',
+				{is_collaboration_restricted_to_enterprise: false}
+			],
+			'upload email access flag': [
+				'--upload-email-access=open',
+				{folder_upload_email: {access: 'open'}}
+			],
+			'sync flag': [
+				'--sync',
+				{sync_state: 'synced'}
+			],
+			'no sync flag': [
+				'--no-sync',
+				{sync_state: 'not_synced'}
+			],
+		}, function(flag, expectedData) {
+
+			test
+				.nock(TEST_API_ROOT, api => api
+					.put(`/2.0/folders/${folderId}`, expectedData)
+					.reply(200, fixture)
+				)
+				.stdout()
+				.stderr()
+				.command([
+					'folders:update',
+					folderId,
+					flag,
+					'--token=test',
+				])
+				.it('should send correct updates when flag is passed');
+		});
 	});
 
 	describe('folders:upload', () => {


### PR DESCRIPTION
Added the `--restrict-to-enterprise` flag for restricting folder collaboration to the owner's enterprise to the `box folders:update` command.  Also fixed a bug in the `--upload-email access` flag in that command.

Fixes #148 