### PR TITLE
Remove non-functional avatar URL flags

### DIFF
--- a/src/commands/users/create.js
+++ b/src/commands/users/create.js
@@ -52,9 +52,6 @@ class UsersCreateCommand extends BoxCommand {
 		if (flags.timezone) {
 			options.timezone = flags.timezone;
 		}
-		if (flags['avatar-url']) {
-			options.avatar_url = flags['avatar-url'];
-		}
 		if (flags['external-id']) {
 			options.external_app_user_id = flags['external-id'];
 		}
@@ -149,7 +146,6 @@ UsersCreateCommand.flags = {
 		]
 	}),
 	timezone: flags.string({ description: 'The user\'s timezone. Input format follows tz database timezones' }),
-	'avatar-url': flags.string({ description: 'URL of the user\'s avatar image' })
 };
 
 UsersCreateCommand.args = [

--- a/src/commands/users/update.js
+++ b/src/commands/users/update.js
@@ -50,9 +50,6 @@ class UsersUpdateCommand extends BoxCommand {
 		if (flags.timezone) {
 			updates.timezone = flags.timezone;
 		}
-		if (flags['avatar-url']) {
-			updates.avatar_url = flags['avatar-url'];
-		}
 		if (flags.remove) {
 			updates.enterprise = null;
 		}
@@ -146,7 +143,6 @@ UsersUpdateCommand.flags = {
 		]
 	}),
 	timezone: flags.string({ description: 'The user\'s timezone. Input format follows tz database timezones' }),
-	'avatar-url': flags.string({ description: 'URL of the user\'s avatar image' }),
 	login: flags.string({ description: 'Change the user\'s primary email address used for logging into Box '}),
 	'external-id': flags.string({
 		description: 'External ID for app users',

--- a/test/commands/users.test.js
+++ b/test/commands/users.test.js
@@ -679,10 +679,6 @@ describe('Users', () => {
 				'--timezone=America/Los_Angeles',
 				{timezone: 'America/Los_Angeles'}
 			],
-			'avatar URL flag': [
-				'--avatar-url=https://example.com/foo.png',
-				{avatar_url: 'https://example.com/foo.png'}
-			],
 		}, function(flag, body) {
 
 			test
@@ -848,10 +844,6 @@ describe('Users', () => {
 			'timezone flag': [
 				'--timezone=America/Los_Angeles',
 				{timezone: 'America/Los_Angeles'}
-			],
-			'avatar URL flag': [
-				'--avatar-url=https://example.com/foo.png',
-				{avatar_url: 'https://example.com/foo.png'}
 			],
 			'role flag': [
 				'--role=coadmin',


### PR DESCRIPTION
The Box API does not currently allow modifying the avatar_url
property on users; the related flags are non-functional and can
be safely removed.