### PR TITLE
Fix restrict collaboration flag

### DIFF
--- a/src/commands/folders/update.js
+++ b/src/commands/folders/update.js
@@ -20,7 +20,7 @@ class FoldersUpdateCommand extends BoxCommand {
 			};
 		}
 		if (flags.hasOwnProperty('restrict-collaboration')) {
-			updates.can_non_owners_invite = flags['restrict-collaboration'];
+			updates.can_non_owners_invite = !flags['restrict-collaboration'];
 		}
 		if (flags.hasOwnProperty('restrict-to-enterprise')) {
 			updates.is_collaboration_restricted_to_enterprise = flags['restrict-to-enterprise'];
@@ -67,7 +67,7 @@ FoldersUpdateCommand.flags = {
 	}),
 	'restrict-to-enterprise': flags.boolean({
 		description: 'Restrict collaboration so only users in the folder owner\'s enterprise can be added',
-		allowNo: true,
+		allowNo: true
 	}),
 	etag: flags.string({ description: 'Only apply updates if the etag value matches' }),
 };

--- a/test/commands/folders.test.js
+++ b/test/commands/folders.test.js
@@ -1286,11 +1286,11 @@ describe('Folders', () => {
 		leche.withData({
 			'restrict collaboration flag': [
 				'--restrict-collaboration',
-				{can_non_owners_invite: true}
+				{can_non_owners_invite: false}
 			],
 			'no restrict collaboration flag': [
 				'--no-restrict-collaboration',
-				{can_non_owners_invite: false}
+				{can_non_owners_invite: true}
 			],
 			'restrict to enterprise flag': [
 				'--restrict-to-enterprise',


### PR DESCRIPTION
The --restrict-collaboration boolean flag on folders:update was reversed. When it was passed as true, the request set can_non_owners_invite as true instead of false.