### PR TITLE
Fix command line flags for bulk commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added `--quiet` flag to suppress any non-error output to stderr
 - Fixed a bug for the `--restrict-collaboration` flag for `box folders:update` where previously the flag would not restrict the collaborations when passed as true and would restrict collaborations when passed as false
 - Added `box trash:restore` to restore a trashed item and `box trash:get` to get information on a trashed item
+- Fixed a bug where flags that can be specified multiple times in a single command could not be passed through the command line for bulk commands
 
 ## 2.4.0 [2019-08-29]
 

--- a/src/box-command.js
+++ b/src/box-command.js
@@ -401,7 +401,17 @@ class BoxCommand extends Command {
 			// be overwritten/combined with later values by the oclif parser
 			Object.keys(this.flags)
 				.filter(flag => flag !== 'bulk-file-path') // Remove the bulk file path flag so we don't recurse!
-				.forEach(flag => this._addFlagToArgv(flag, this.flags[flag]));
+				.forEach(flag => {
+					// Some flags can be specified multiple times in a single command. For these flags, their value is an array of user inputted values.
+					// For these flags, we iterate through their values and add each one as a separate flag to comply with oclif
+					if (Array.isArray(this.flags[flag])) {
+						(this.flags[flag]).forEach(value => {
+							this._addFlagToArgv(flag, value);
+						});
+					} else {
+						this._addFlagToArgv(flag, this.flags[flag]);
+					}
+				});
 
 			// Include all flag values from bulk input, which will override earlier ones
 			// from the command line

--- a/test/commands/bulk.test.js
+++ b/test/commands/bulk.test.js
@@ -24,7 +24,7 @@ describe('Bulk', () => {
 		sandbox.verifyAndRestore();
 	});
 
-	describe('CSV Input', () => {
+	describe.only('CSV Input', () => {
 		let inputFilePath = path.join(__dirname, '..', 'fixtures/bulk/input.csv'),
 			saveFilePath = path.join(__dirname, '..', 'fixtures/bulk/saveTest.txt'),
 			csvOutput = getFixture('bulk/post_collaborations_csv.csv'),
@@ -199,6 +199,35 @@ describe('Bulk', () => {
 				'--token=test'
 			])
 			.it('should permit keys that do not use flag punctuation');
+
+		let folderLockBody = {
+			folder: {
+				type: 'folder',
+				id: '1243215'
+			}
+		};
+		let folderLockBodyString = JSON.stringify(folderLockBody);
+		let folderLockInputFilePath = path.join(__dirname, '../fixtures/bulk/input_manual_request_folder_lock.csv');
+		let folderLockBodyFixture = getFixture('bulk/post_folders_lock.json');
+		test
+			.nock(TEST_API_ROOT, api => api
+				.matchHeader('Content-Type', 'application/json;version=1')
+				.matchHeader('Accept', 'application/json;version=1')
+				.post('/2.0/folder_locks', folderLockBody)
+				.reply(200, folderLockBodyFixture)
+			)
+			.stdout()
+			.stderr()
+			.command([
+				'request',
+				`--body=${folderLockBodyString}`,
+				'--header=Content-Type: application/json;version=1',
+				'--header=Accept: application/json;version=1',
+				`--bulk-file-path=${folderLockInputFilePath}`,
+				'--json',
+				'--token=test'
+			])
+			.it('should allow flags that can be specified multiple times in a single command to be passed through the command line for bulk commands');
 
 		test
 			.nock(TEST_API_ROOT, api => api

--- a/test/commands/bulk.test.js
+++ b/test/commands/bulk.test.js
@@ -24,7 +24,7 @@ describe('Bulk', () => {
 		sandbox.verifyAndRestore();
 	});
 
-	describe.only('CSV Input', () => {
+	describe('CSV Input', () => {
 		let inputFilePath = path.join(__dirname, '..', 'fixtures/bulk/input.csv'),
 			saveFilePath = path.join(__dirname, '..', 'fixtures/bulk/saveTest.txt'),
 			csvOutput = getFixture('bulk/post_collaborations_csv.csv'),

--- a/test/fixtures/bulk/input_manual_request_folder_lock.csv
+++ b/test/fixtures/bulk/input_manual_request_folder_lock.csv
@@ -1,0 +1,2 @@
+RESOURCE,method
+https://api.box.com/2.0/folder_locks,POST

--- a/test/fixtures/bulk/post_folders_lock.json
+++ b/test/fixtures/bulk/post_folders_lock.json
@@ -1,0 +1,17 @@
+{
+    "folder": {
+      "type": "folder",
+      "id": "123",
+      "sequence_id": "1",
+      "etag": "1",
+      "name": "locked_folder"
+    },
+    "id": "2648",
+    "type": "folder_lock",
+    "created_by": {
+      "id": "1111",
+      "type": "user"
+    },
+    "created_at": "2019-10-17T18:06:36Z",
+    "lock_type": "freeze"
+  }


### PR DESCRIPTION
Fixed a bug where flags that can be specified multiple times in a single command could not be passed through the command line for bulk commands