### PR TITLE
Fix filename issue when saving reports on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Next Release
+- Fix filename issue when saving reports on Windows 
+
 ## 2.5.1 [2020-04-14]
 
 - Added `--quiet` flag to suppress any non-error output to stderr

--- a/src/box-command.js
+++ b/src/box-command.js
@@ -700,7 +700,7 @@ class BoxCommand extends Command {
 	 */
 	_getOutputFileName() {
 		let extension = this._getOutputFormat();
-		return `${this.id.replace(':', '-')}-${dateTime.format(new Date(), 'YYYY-MM-DD_HH_mm_ss_SSS')}.${extension}`;
+		return `${this.id.replace(/:/gu, '-')}-${dateTime.format(new Date(), 'YYYY-MM-DD_HH_mm_ss_SSS')}.${extension}`;
 	}
 
 	/**

--- a/src/commands/oss.js
+++ b/src/commands/oss.js
@@ -7,9 +7,9 @@ const path = require('path');
 class OSSLicensesCommand extends BoxCommand {
 	async run() {
 
-        let licensesFilePath = path.resolve(__dirname, '../../LICENSE-THIRD-PARTY.txt');
+		let licensesFilePath = path.resolve(__dirname, '../../LICENSE-THIRD-PARTY.txt');
 
-        let licenseText = await fs.readFile(licensesFilePath, 'utf8');
+		let licenseText = await fs.readFile(licensesFilePath, 'utf8');
 
 		await this.output(licenseText);
 	}

--- a/test/box-command.test.js
+++ b/test/box-command.test.js
@@ -50,6 +50,22 @@ describe('BoxCommand', () => {
 				'--token=test'
 			])
 			.it('should send correct analytics and identification headers with API requests');
+
+		test
+			.nock(TEST_API_ROOT, api => api
+				.post('/2.0/collaborations')
+				.reply(200, {})
+			)
+			.stderr()
+			.command([
+				'folders:collaborations:add',
+				'0',
+				'--save'
+			])
+			.it('should save output to file with correct naming conventions', ctx => {
+				assert.include(ctx.stderr, 'folders-collaborations-add');
+				assert.notInclude(ctx.stderr, ':');
+			});
 	});
 
 	describe('normalizeDateString()', () => {

--- a/test/box-command.test.js
+++ b/test/box-command.test.js
@@ -62,7 +62,7 @@ describe('BoxCommand', () => {
 				'0',
 				'--save'
 			])
-			.it('should save output to file with correct naming conventions', ctx => {
+			.it('should save output to file named with valid characters', ctx => {
 				assert.include(ctx.stderr, 'folders-collaborations-add');
 				assert.notInclude(ctx.stderr, ':');
 			});


### PR DESCRIPTION
When saving output to disk, the generated filename would sometimes include a `:`. This is not a valid character for filenames on Windows. Now all `:` are replaced with `-`.

To generate the filename, we concatenate the command being run with the date and other values. The command being run often has `:` in it. Previously, our code replaced the first occurrence of `:` with a `-` and left the remaining occurrences of `:`. So for commands where there are multiple `:`, the invalid characters would remain. Now, we replace all occurrences of `:`. 