### PR TITLE
Add filter_term parameter to groups:list

### DIFF
--- a/src/commands/groups/index.js
+++ b/src/commands/groups/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BoxCommand = require('../../box-command');
+const { flags } = require('@oclif/command');
 
 class GroupsListCommand extends BoxCommand {
 	async run() {
@@ -9,6 +10,10 @@ class GroupsListCommand extends BoxCommand {
 
 		if (flags.fields) {
 			options.fields = flags.fields;
+		}
+
+		if (flags.filter) {
+			options.filter_term = flags.filter;
 		}
 
 		let groups = await this.client.groups.getAll(options);
@@ -23,7 +28,10 @@ GroupsListCommand.examples = ['box groups'];
 GroupsListCommand._endpoint = 'get_groups';
 
 GroupsListCommand.flags = {
-	...BoxCommand.flags
+	...BoxCommand.flags,
+	filter: flags.string({
+		description: 'Search term to filter groups on; matches prefixes of group name',
+	})
 };
 
 module.exports = GroupsListCommand;

--- a/test/commands/groups.test.js
+++ b/test/commands/groups.test.js
@@ -110,6 +110,27 @@ describe('Groups', () => {
 					'--token=test'
 				])
 				.it('should send fields param to the API when --fields flag is passed');
+
+			test
+				.nock(TEST_API_ROOT, api => api
+					.get('/2.0/groups')
+					.query({filter_term: 'Employees'})
+					.reply(200, fixture)
+					.get('/2.0/groups')
+					.query({
+						filter_term: 'Employees',
+						offset: 2
+					})
+					.reply(200, fixture2)
+				)
+				.stdout()
+				.command([
+					command,
+					'--filter=Employees',
+					'--json',
+					'--token=test'
+				])
+				.it('should send filter_term param to the API when --filter flag is passed');
 		});
 	});
 


### PR DESCRIPTION
ref: https://developer.box.com/changelog/#2020-09-10-group-api-adds-new-filter-and-permissions
Support `--filter` option to `groups:list` command.