### PR TITLE
Reveal hidden help documents

### DIFF
--- a/src/commands/collaborations/create.js
+++ b/src/commands/collaborations/create.js
@@ -15,8 +15,6 @@ class CollaborationsAddCommand extends BoxCommand {
 	}
 }
 
-CollaborationsAddCommand.hidden = true;
-
 CollaborationsAddCommand.aliases = [ 'collaborations:add' ];
 
 CollaborationsAddCommand.description = 'Create a collaboration for a Box item';

--- a/src/commands/shared-links/create.js
+++ b/src/commands/shared-links/create.js
@@ -16,8 +16,6 @@ class SharedLinksCreateCommand extends BoxCommand {
 
 SharedLinksCreateCommand.aliases = ['shared-links:update'];
 
-SharedLinksCreateCommand.hidden = true;
-
 SharedLinksCreateCommand.description = 'Create a shared link for a Box item';
 SharedLinksCreateCommand.examples = ['box shared-links:create 22222 folder --access company'];
 

--- a/src/commands/shared-links/delete.js
+++ b/src/commands/shared-links/delete.js
@@ -14,8 +14,6 @@ class SharedLinksDeleteCommand extends BoxCommand {
 	}
 }
 
-SharedLinksDeleteCommand.hidden = true;
-
 SharedLinksDeleteCommand.description = 'Delete a shared link for a Box item';
 SharedLinksDeleteCommand.examples = ['box shared-links:delete folder 22222'];
 

--- a/src/commands/users/search.js
+++ b/src/commands/users/search.js
@@ -17,8 +17,6 @@ class UsersSearchCommand extends BoxCommand {
 	}
 }
 
-UsersSearchCommand.hidden = true;
-
 UsersSearchCommand.description = 'Search for Box users';
 UsersSearchCommand.examples = ['box users:search "John Doe"'];
 


### PR DESCRIPTION
The documentation for some commands was hidden, so I made them public.

### Before

```sh
$ box shared-links --help
Manage shared links

USAGE
  $ box shared-links:COMMAND

COMMANDS
  shared-links:get  Get information from a shared item URL

```

### After

```sh
$ box shared-links --help
Manage shared links

USAGE
  $ box shared-links:COMMAND

COMMANDS
  shared-links:create  Create a shared link for a Box item
  shared-links:delete  Delete a shared link for a Box item
  shared-links:get     Get information from a shared item URL
```