### PR TITLE
Fix bug with setting proxy settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 **New Features and Enhancements:**
 
-- Add filter_term parameter to `groups:list`
-- Make commands `collaborations:add`, `shared-links:update`, `shared-links:delete`, `users:search` that were previously hidden, now available
+- Add `filter_term` parameter to `groups:list` ([210](https://github.com/box/boxcli/pull/210))
+- Make commands `collaborations:add`, `shared-links:update`, `shared-links:delete`, `users:search` that were previously hidden, now available ([211](https://github.com/box/boxcli/pull/211))
 
 **Bug Fixes:**
 
-- 
+- Fix bug with setting proxy settings ([213](https://github.com/box/boxcli/pull/213))
 
 ## 2.6.0 [2020-08-20]
 

--- a/src/box-command.js
+++ b/src/box-command.js
@@ -982,6 +982,8 @@ class BoxCommand extends Command {
 	 */
 	updateSettings(updatedSettings) {
 		this.settings = Object.assign(this.settings, updatedSettings);
+		console.log(this.settings)
+		console.log(updatedSettings)
 		try {
 			fs.writeFileSync(SETTINGS_FILE_PATH, JSON.stringify(this.settings, null, 4), 'utf8');
 		} catch (ex) {
@@ -1051,6 +1053,7 @@ class BoxCommand extends Command {
 		let settings;
 		try {
 			settings = JSON.parse(fs.readFileSync(SETTINGS_FILE_PATH));
+			settings = Object.assign(this._getDefaultSettings(), settings);
 			DEBUG.init('Loaded settings %O', settings);
 		} catch (ex) {
 			throw new BoxCLIError(`Could not read CLI settings file at ${SETTINGS_FILE_PATH}`, ex);
@@ -1086,7 +1089,7 @@ class BoxCommand extends Command {
 			boxReportsFileFormat: 'txt',
 			boxDownloadsFolderPath: path.join(os.homedir(), 'Downloads/Box-Downloads'),
 			outputJson: false,
-			enableProxy: true,
+			enableProxy: false,
 			proxy: {
 				url: null,
 				username: null,

--- a/src/box-command.js
+++ b/src/box-command.js
@@ -982,8 +982,6 @@ class BoxCommand extends Command {
 	 */
 	updateSettings(updatedSettings) {
 		this.settings = Object.assign(this.settings, updatedSettings);
-		console.log(this.settings)
-		console.log(updatedSettings)
 		try {
 			fs.writeFileSync(SETTINGS_FILE_PATH, JSON.stringify(this.settings, null, 4), 'utf8');
 		} catch (ex) {


### PR DESCRIPTION
If a user has an existing `settings.json` file from an older version of the CLI without proxy settings, then when they download a newer version of the CLI with support for proxy settings, they won't be able to set any proxy settings. A user can only set proxy settings if they delete their old `settings.json` in the `.box` folder in their root directory or never had one in the first place. 