### PR TITLE
Output contents of array for bulk commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Next Release
+
+**New Features and Enhancements:**
+
+- Output contents of array for bulk commands ([#217](https://github.com/box/boxcli/pull/217))
+
 ## 2.7.0 (2020-11-02)
 
 **New Features and Enhancements:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 **New Features and Enhancements:**
 
-- Output contents of array for bulk commands ([#217](https://github.com/box/boxcli/pull/217))
+- Output contents of array for bulk commands (#217)
 
 **Bug Fixes:**
 
-- Fix bug with setting proxy settings ([#218](https://github.com/box/boxcli/pull/218))
+- Fix bug with setting proxy settings (#218)
 
 ## 2.7.0 (2020-11-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,15 @@
 
 **Warning:**
 
-- Due to the changes in #217, additional details about Box Items may now be returned for some commands.
+- Due to the changes in ([#217](https://github.com/box/boxcli/pull/217)), additional details about Box Items may now be returned for some commands.
 
 **New Features and Enhancements:**
 
-- Output contents of array for bulk commands (#217)
+- Output contents of array for bulk commands ([#217](https://github.com/box/boxcli/pull/217))
 
 **Bug Fixes:**
 
-- Fix bug with setting proxy settings (#218)
+- Fix bug with setting proxy settings ([#218](https://github.com/box/boxcli/pull/218))
 
 ## 2.7.0 (2020-11-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next Release
 
+**Warning:**
+
+- Due to the changes in #217, additional details about Box Items may now be returned for some commands.
+
 **New Features and Enhancements:**
 
 - Output contents of array for bulk commands (#217)

--- a/src/box-command.js
+++ b/src/box-command.js
@@ -891,9 +891,7 @@ class BoxCommand extends Command {
 			if (typeof (object) === 'object') {
 				for (let keyPath of keyPaths) {
 					let value = _.get(object, keyPath);
-					if (Array.isArray(value)) {
-						row.push(value);
-					} else if (value === null || value === undefined) {
+					if (value === null || value === undefined) {
 						row.push('');
 					} else {
 						row.push(value);

--- a/src/box-command.js
+++ b/src/box-command.js
@@ -892,7 +892,7 @@ class BoxCommand extends Command {
 				for (let keyPath of keyPaths) {
 					let value = _.get(object, keyPath);
 					if (Array.isArray(value)) {
-						row.push('Array');
+						row.push(value);
 					} else if (value === null || value === undefined) {
 						row.push('');
 					} else {


### PR DESCRIPTION
For bulk commands where the output is CSV, arrays are outputted as `Array` rather than outputting the content of the arrays. This is now changed.