### PR TITLE
Fix box events issue with no stream position

### DIFF
--- a/src/commands/events/index.js
+++ b/src/commands/events/index.js
@@ -39,7 +39,7 @@ class EventsGetCommand extends BoxCommand {
 
 		let events = await this.client.events.get(options);
 
-		if (options.stream_position) {
+		if (options.stream_position || options.stream_type !== 'admin_logs') {
 			await this.output(events);
 		} else {
 			let allEvents = [].concat(events.entries); // Copy the first page of events

--- a/test/commands/events.test.js
+++ b/test/commands/events.test.js
@@ -102,6 +102,25 @@ describe('Events', () => {
 				.nock(TEST_API_ROOT, api => api
 					.get('/2.0/events')
 					.query({
+						limit: '10',
+					})
+					.reply(200, fixture)
+				)
+				.stdout()
+				.command([
+					command,
+					'--limit=10',
+					'--json',
+					'--token=test'
+				])
+				.it('should get user events when neither --stream-position nor --enterprise flags are passed', ctx => {
+					assert.equal(ctx.stdout, fixture);
+				});
+
+			test
+				.nock(TEST_API_ROOT, api => api
+					.get('/2.0/events')
+					.query({
 						created_before: '2018-07-13T19:00:00+00:00',
 						created_after: '2018-07-08T19:00:00+00:00',
 						stream_type: 'admin_logs'


### PR DESCRIPTION
Fixes https://github.com/box/boxcli/issues/229

The `box events` command was expecting that the user passes in either a stream position (in which case we return a single page of results), or a closed date-time range (in which case we page through the events results for the given date range). However, time range parameters are ignored if `stream_type` is anything other than `admin_logs` (see [docs](https://developer.box.com/reference/get-events/)). So if a user does not pass in either the stream position or enterprise flags, the default behavior should be to return all results (which is the default behavior of the API when stream position is null or 0).