### PR TITLE
Add more details on environment config token caching

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -141,7 +141,9 @@ OPTIONS
   -h, --help                           Show CLI help
   -q, --quiet                          Suppress any non-error output to stderr
   -v, --verbose                        Show verbose output, which can be helpful for debugging
-  --[no-]cache-tokens                  Enable token caching, which significantly improves performance
+  --[no-]cache-tokens                  Enable token caching, which significantly improves performance.
+                                       Run with --no-cache-tokens and then --cache-tokens if your
+                                       application config updates are not reflected in your requests.
   --config-file-path=config-file-path  Provide a file path to configuration file
   --name=name                          New name of the environment
   --no-color                           Turn off colors for logging

--- a/src/commands/configure/environments/update.js
+++ b/src/commands/configure/environments/update.js
@@ -77,7 +77,7 @@ EnvironmentsUpdateCommand.flags = {
 	}),
 	'user-id': flags.string({ description: 'Store a default user ID to use with the session commands. A default user ID can be stored for each Box environment' }),
 	'cache-tokens': flags.boolean({
-		description: 'Enable token caching, which significantly improves performance',
+		description: 'Enable token caching, which significantly improves performance. Run with --no-cache-tokens and then --cache-tokens if your application config updates are not reflected in your requests.',
 		allowNo: true,
 	}),
 };


### PR DESCRIPTION
When you update the configuration of your application in the Box Developer Console, your CLI requests can occasionally still use the stale/outdated config. Using the --no-cache-tokens flag is a way to force your token to refresh so your CLI requests pick up the latest config updates.