### PR TITLE
Add support note to the mdfilter equality check in search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **New Features and Enhancements**
 
 - Add support for copyInstanceOnItemCopy field for metadata templates  ([#239](https://github.com/box/boxcli/pull/239))
+- Add support note to the mdfilter equality check in search ([#253](https://github.com/box/boxcli/pull/253))
 
 ## 2.9.0 (2021-02-22)
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -54,9 +54,9 @@ OPTIONS
 
   --mdfilter=mdfilter                            Metadata value to filter on, in the format
                                                  <scope>.<templateKey>.<field><op><value>
-                                                 <op> is either <, = or >
-                                                 Note: Equality check is not supported for numeric fields. You can
-                                                 use < and > for less than or equal/greater than or equal checks.
+                                                 <op> is either = for strings or <,=,> for numbers and dates
+                                                 When providing numeric value, follow it with "f"
+                                                 eg. enterprise.employeeRecord.joinedYear=2021f
 
   --no-color                                     Turn off colors for logging
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -53,7 +53,10 @@ OPTIONS
   --json                                         Output formatted JSON
 
   --mdfilter=mdfilter                            Metadata value to filter on, in the format
-                                                 <scope>.<templateKey>.<field>=<value>
+                                                 <scope>.<templateKey>.<field><op><value>
+                                                 <op> is either <, = or >
+                                                 Note: Equality check is not supported for numeric fields. You can
+                                                 use < and > for less than or equal/greater than or equal checks.
 
   --no-color                                     Turn off colors for logging
 

--- a/src/commands/search.js
+++ b/src/commands/search.js
@@ -73,7 +73,7 @@ class SearchCommand extends BoxCommand {
 				filters.forEach(({field, cmp, value}) => {
 					if (cmp === '=') {
 						if (typeof value === 'number') {
-							filtersObj[field] = {lt: value, gt:value};
+							filtersObj[field] = {lt: value, gt: value};
 						} else {
 							filtersObj[field] = value;
 						}

--- a/src/commands/search.js
+++ b/src/commands/search.js
@@ -72,12 +72,11 @@ class SearchCommand extends BoxCommand {
 				// Build the filters object, e.g {"field1": value1, "field2": {"lt": value2}}
 				filters.forEach(({field, cmp, value}) => {
 					if (cmp === '=') {
-						// NOTE this is not supported for numeric fields
 						if (typeof value === 'number') {
-							throw new BoxCLIError('Equality comparator is not supported for numeric values');
+							filtersObj[field] = {lt: value, gt:value};
+						} else {
+							filtersObj[field] = value;
 						}
-
-						filtersObj[field] = value;
 					} else if (cmp === '<') {
 						filtersObj[field] = {lt: value};
 					} else if (cmp === '>') {

--- a/src/commands/search.js
+++ b/src/commands/search.js
@@ -71,7 +71,12 @@ class SearchCommand extends BoxCommand {
 
 				// Build the filters object, e.g {"field1": value1, "field2": {"lt": value2}}
 				filters.forEach(({field, cmp, value}) => {
-					if (cmp === '=') { // NOTE this is not supported for numeric fields
+					if (cmp === '=') {
+						// NOTE this is not supported for numeric fields
+						if (typeof value === 'number') {
+							throw new BoxCLIError('Equality comparator is not supported for numeric values');
+						}
+
 						filtersObj[field] = value;
 					} else if (cmp === '<') {
 						filtersObj[field] = {lt: value};

--- a/src/commands/search.js
+++ b/src/commands/search.js
@@ -71,7 +71,7 @@ class SearchCommand extends BoxCommand {
 
 				// Build the filters object, e.g {"field1": value1, "field2": {"lt": value2}}
 				filters.forEach(({field, cmp, value}) => {
-					if (cmp === '=') {
+					if (cmp === '=') { // NOTE this is not supported for numeric fields
 						filtersObj[field] = value;
 					} else if (cmp === '<') {
 						filtersObj[field] = {lt: value};

--- a/test/commands/bulk.test.js
+++ b/test/commands/bulk.test.js
@@ -740,7 +740,7 @@ describe('Bulk', () => {
 			.nock(TEST_API_ROOT, api => api
 				.get('/2.0/search')
 				.query({
-					mdfilters: '[{"scope":"enterprise","templateKey":"myTemplate","filters":{"name":"Matt","age":30}}]',
+					mdfilters: '[{"scope":"enterprise","templateKey":"myTemplate","filters":{"name":"Matt","age":{"lt":30,"gt":30}}}]',
 					limit: 100,
 					query: '',
 				})

--- a/test/commands/bulk.test.js
+++ b/test/commands/bulk.test.js
@@ -233,7 +233,7 @@ describe('Bulk', () => {
 			.nock(TEST_API_ROOT, api => api
 				.get('/2.0/search')
 				.query({
-					mdfilters: '[{"scope":"enterprise","templateKey":"myTemplate","filters":{"name":"Matt","age":30}}]',
+					mdfilters: '[{"scope":"enterprise","templateKey":"myTemplate","filters":{"name":"Matt","age":{"lt":30,"gt":30}}}]',
 					limit: 100,
 					query: '',
 				})

--- a/test/commands/search.test.js
+++ b/test/commands/search.test.js
@@ -256,7 +256,10 @@ describe('Search', () => {
 							templateKey: 'properties',
 							filters: {
 								foo: 'barf',
-								money: 3.51,
+								money: {
+									lt: 3.51,
+									gt: 3.51,
+								},
 							},
 						},
 						{


### PR DESCRIPTION
Verified that:

```
[{
    scope: 'enterprise_27335',
    templateKey: 'VendorContract',
    filters: {
        value: {
            lt: 436442,
            gt: 436442,
        },
    },
}]|
```

is a valid argument for numeric equality search using mdfilter and the correct way for doing equality check https://developer.box.com/guides/search/metadata-filters/.