### PR TITLE
fix: support large output when using `json` flag by replacing `json.stringify`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
 		},
 		"@babel/helper-validator-identifier": {
 			"version": "7.16.7",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
 			"integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
 			"dev": true
 		},
@@ -136,9 +136,14 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@discoveryjs/json-ext": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+			"integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw=="
+		},
 		"@hutson/parse-repository-url": {
 			"version": "3.0.2",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz",
 			"integrity": "sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==",
 			"dev": true
 		},
@@ -628,7 +633,7 @@
 		},
 		"@types/minimist": {
 			"version": "1.2.2",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/@types/minimist/-/minimist-1.2.2.tgz",
+			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
 			"dev": true
 		},
@@ -654,7 +659,7 @@
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.1",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
 			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
 			"dev": true
 		},
@@ -666,7 +671,7 @@
 		},
 		"JSONStream": {
 			"version": "1.3.5",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/JSONStream/-/JSONStream-1.3.5.tgz",
+			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
 			"integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
 			"dev": true,
 			"requires": {
@@ -1309,7 +1314,7 @@
 		},
 		"buffer-from": {
 			"version": "1.1.2",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/buffer-from/-/buffer-from-1.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
 			"dev": true
 		},
@@ -1379,13 +1384,13 @@
 		},
 		"camelcase": {
 			"version": "5.3.1",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/camelcase/-/camelcase-5.3.1.tgz",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 			"dev": true
 		},
 		"camelcase-keys": {
 			"version": "6.2.2",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
 			"integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
 			"dev": true,
 			"requires": {
@@ -1837,7 +1842,7 @@
 		},
 		"compare-func": {
 			"version": "2.0.0",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/compare-func/-/compare-func-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
 			"integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
 			"dev": true,
 			"requires": {
@@ -1879,7 +1884,7 @@
 		},
 		"concat-stream": {
 			"version": "2.0.0",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/concat-stream/-/concat-stream-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
 			"integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
 			"dev": true,
 			"requires": {
@@ -1891,7 +1896,7 @@
 			"dependencies": {
 				"readable-stream": {
 					"version": "3.6.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/readable-stream/-/readable-stream-3.6.0.tgz",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
 					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"dev": true,
 					"requires": {
@@ -1949,7 +1954,7 @@
 		},
 		"conventional-changelog-angular": {
 			"version": "5.0.13",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
 			"integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
 			"dev": true,
 			"requires": {
@@ -1959,7 +1964,7 @@
 		},
 		"conventional-changelog-atom": {
 			"version": "2.0.8",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/conventional-changelog-atom/-/conventional-changelog-atom-2.0.8.tgz",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-2.0.8.tgz",
 			"integrity": "sha512-xo6v46icsFTK3bb7dY/8m2qvc8sZemRgdqLb/bjpBsH2UyOS8rKNTgcb5025Hri6IpANPApbXMg15QLb1LJpBw==",
 			"dev": true,
 			"requires": {
@@ -1968,7 +1973,7 @@
 		},
 		"conventional-changelog-codemirror": {
 			"version": "2.0.8",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/conventional-changelog-codemirror/-/conventional-changelog-codemirror-2.0.8.tgz",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-2.0.8.tgz",
 			"integrity": "sha512-z5DAsn3uj1Vfp7po3gpt2Boc+Bdwmw2++ZHa5Ak9k0UKsYAO5mH1UBTN0qSCuJZREIhX6WU4E1p3IW2oRCNzQw==",
 			"dev": true,
 			"requires": {
@@ -1977,7 +1982,7 @@
 		},
 		"conventional-changelog-config-spec": {
 			"version": "2.1.0",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/conventional-changelog-config-spec/-/conventional-changelog-config-spec-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-config-spec/-/conventional-changelog-config-spec-2.1.0.tgz",
 			"integrity": "sha512-IpVePh16EbbB02V+UA+HQnnPIohgXvJRxHcS5+Uwk4AT5LjzCZJm5sp/yqs5C6KZJ1jMsV4paEV13BN1pvDuxQ==",
 			"dev": true
 		},
@@ -1994,7 +1999,7 @@
 		},
 		"conventional-changelog-core": {
 			"version": "4.2.4",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/conventional-changelog-core/-/conventional-changelog-core-4.2.4.tgz",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-4.2.4.tgz",
 			"integrity": "sha512-gDVS+zVJHE2v4SLc6B0sLsPiloR0ygU7HaDW14aNJE1v4SlqJPILPl/aJC7YdtRE4CybBf8gDwObBvKha8Xlyg==",
 			"dev": true,
 			"requires": {
@@ -2016,7 +2021,7 @@
 			"dependencies": {
 				"hosted-git-info": {
 					"version": "4.1.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
 					"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
 					"dev": true,
 					"requires": {
@@ -2025,7 +2030,7 @@
 				},
 				"lru-cache": {
 					"version": "6.0.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/lru-cache/-/lru-cache-6.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 					"dev": true,
 					"requires": {
@@ -2034,7 +2039,7 @@
 				},
 				"normalize-package-data": {
 					"version": "3.0.3",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
 					"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
 					"dev": true,
 					"requires": {
@@ -2046,7 +2051,7 @@
 				},
 				"semver": {
 					"version": "7.3.7",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/semver/-/semver-7.3.7.tgz",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
 					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
 					"dev": true,
 					"requires": {
@@ -2055,7 +2060,7 @@
 				},
 				"yallist": {
 					"version": "4.0.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/yallist/-/yallist-4.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 					"dev": true
 				}
@@ -2063,7 +2068,7 @@
 		},
 		"conventional-changelog-ember": {
 			"version": "2.0.9",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/conventional-changelog-ember/-/conventional-changelog-ember-2.0.9.tgz",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-2.0.9.tgz",
 			"integrity": "sha512-ulzIReoZEvZCBDhcNYfDIsLTHzYHc7awh+eI44ZtV5cx6LVxLlVtEmcO+2/kGIHGtw+qVabJYjdI5cJOQgXh1A==",
 			"dev": true,
 			"requires": {
@@ -2072,7 +2077,7 @@
 		},
 		"conventional-changelog-eslint": {
 			"version": "3.0.9",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/conventional-changelog-eslint/-/conventional-changelog-eslint-3.0.9.tgz",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-3.0.9.tgz",
 			"integrity": "sha512-6NpUCMgU8qmWmyAMSZO5NrRd7rTgErjrm4VASam2u5jrZS0n38V7Y9CzTtLT2qwz5xEChDR4BduoWIr8TfwvXA==",
 			"dev": true,
 			"requires": {
@@ -2081,7 +2086,7 @@
 		},
 		"conventional-changelog-express": {
 			"version": "2.0.6",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/conventional-changelog-express/-/conventional-changelog-express-2.0.6.tgz",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-2.0.6.tgz",
 			"integrity": "sha512-SDez2f3iVJw6V563O3pRtNwXtQaSmEfTCaTBPCqn0oG0mfkq0rX4hHBq5P7De2MncoRixrALj3u3oQsNK+Q0pQ==",
 			"dev": true,
 			"requires": {
@@ -2090,7 +2095,7 @@
 		},
 		"conventional-changelog-jquery": {
 			"version": "3.0.11",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/conventional-changelog-jquery/-/conventional-changelog-jquery-3.0.11.tgz",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-3.0.11.tgz",
 			"integrity": "sha512-x8AWz5/Td55F7+o/9LQ6cQIPwrCjfJQ5Zmfqi8thwUEKHstEn4kTIofXub7plf1xvFA2TqhZlq7fy5OmV6BOMw==",
 			"dev": true,
 			"requires": {
@@ -2099,7 +2104,7 @@
 		},
 		"conventional-changelog-jshint": {
 			"version": "2.0.9",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/conventional-changelog-jshint/-/conventional-changelog-jshint-2.0.9.tgz",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-2.0.9.tgz",
 			"integrity": "sha512-wMLdaIzq6TNnMHMy31hql02OEQ8nCQfExw1SE0hYL5KvU+JCTuPaDO+7JiogGT2gJAxiUGATdtYYfh+nT+6riA==",
 			"dev": true,
 			"requires": {
@@ -2109,13 +2114,13 @@
 		},
 		"conventional-changelog-preset-loader": {
 			"version": "2.3.4",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.3.4.tgz",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.3.4.tgz",
 			"integrity": "sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g==",
 			"dev": true
 		},
 		"conventional-changelog-writer": {
 			"version": "5.0.1",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/conventional-changelog-writer/-/conventional-changelog-writer-5.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.1.tgz",
 			"integrity": "sha512-5WsuKUfxW7suLblAbFnxAcrvf6r+0b7GvNaWUwUIk0bXMnENP/PEieGKVUQrjPqwPT4o3EPAASBXiY6iHooLOQ==",
 			"dev": true,
 			"requires": {
@@ -2132,7 +2137,7 @@
 			"dependencies": {
 				"semver": {
 					"version": "6.3.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/semver/-/semver-6.3.0.tgz",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				}
@@ -2140,7 +2145,7 @@
 		},
 		"conventional-commits-filter": {
 			"version": "2.0.7",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz",
+			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz",
 			"integrity": "sha512-ASS9SamOP4TbCClsRHxIHXRfcGCnIoQqkvAzCSbZzTFLfcTqJVugB0agRgsEELsqaeWgsXv513eS116wnlSSPA==",
 			"dev": true,
 			"requires": {
@@ -2150,7 +2155,7 @@
 		},
 		"conventional-commits-parser": {
 			"version": "3.2.4",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz",
+			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz",
 			"integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
 			"dev": true,
 			"requires": {
@@ -2164,7 +2169,7 @@
 		},
 		"conventional-recommended-bump": {
 			"version": "6.1.0",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/conventional-recommended-bump/-/conventional-recommended-bump-6.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-6.1.0.tgz",
 			"integrity": "sha512-uiApbSiNGM/kkdL9GTOLAqC4hbptObFo4wW2QRyHsKciGAfQuLU1ShZ1BIVI/+K2BE/W1AWYQMCXAsv4dyKPaw==",
 			"dev": true,
 			"requires": {
@@ -2259,7 +2264,7 @@
 		},
 		"dargs": {
 			"version": "7.0.0",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/dargs/-/dargs-7.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
 			"integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
 			"dev": true
 		},
@@ -2283,7 +2288,7 @@
 		},
 		"dateformat": {
 			"version": "3.0.3",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/dateformat/-/dateformat-3.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
 			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
 			"dev": true
 		},
@@ -2309,7 +2314,7 @@
 		},
 		"decamelize-keys": {
 			"version": "1.1.0",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
 			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
 			"dev": true,
 			"requires": {
@@ -2319,7 +2324,7 @@
 			"dependencies": {
 				"map-obj": {
 					"version": "1.0.1",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/map-obj/-/map-obj-1.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
 					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
 					"dev": true
 				}
@@ -2500,7 +2505,7 @@
 		},
 		"detect-newline": {
 			"version": "3.1.0",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/detect-newline/-/detect-newline-3.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
 			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
 			"dev": true
 		},
@@ -2531,7 +2536,7 @@
 		},
 		"dot-prop": {
 			"version": "5.3.0",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/dot-prop/-/dot-prop-5.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
 			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
 			"dev": true,
 			"requires": {
@@ -2540,7 +2545,7 @@
 		},
 		"dotgitignore": {
 			"version": "2.1.0",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/dotgitignore/-/dotgitignore-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/dotgitignore/-/dotgitignore-2.1.0.tgz",
 			"integrity": "sha512-sCm11ak2oY6DglEPpCB8TixLjWAxd3kJTs6UIcSasNYxXdFPV+YKlye92c8H4kKFqV5qYMIh7d+cYecEg0dIkA==",
 			"dev": true,
 			"requires": {
@@ -2550,7 +2555,7 @@
 			"dependencies": {
 				"find-up": {
 					"version": "3.0.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/find-up/-/find-up-3.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
 					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 					"dev": true,
 					"requires": {
@@ -2559,7 +2564,7 @@
 				},
 				"locate-path": {
 					"version": "3.0.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/locate-path/-/locate-path-3.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
 					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 					"dev": true,
 					"requires": {
@@ -2569,7 +2574,7 @@
 				},
 				"p-limit": {
 					"version": "2.3.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/p-limit/-/p-limit-2.3.0.tgz",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
 					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 					"dev": true,
 					"requires": {
@@ -2578,7 +2583,7 @@
 				},
 				"p-locate": {
 					"version": "3.0.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/p-locate/-/p-locate-3.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
 					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 					"dev": true,
 					"requires": {
@@ -2587,7 +2592,7 @@
 				},
 				"p-try": {
 					"version": "2.2.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/p-try/-/p-try-2.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				}
@@ -3582,7 +3587,7 @@
 		},
 		"get-pkg-repo": {
 			"version": "4.2.1",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/get-pkg-repo/-/get-pkg-repo-4.2.1.tgz",
+			"resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-4.2.1.tgz",
 			"integrity": "sha512-2+QbHjFRfGB74v/pYWjd5OhU3TDIC2Gv/YKUTk/tCvAz0pkn/Mz6P3uByuBimLOcPvN2jYdScl3xGFSrx0jEcA==",
 			"dev": true,
 			"requires": {
@@ -3594,7 +3599,7 @@
 			"dependencies": {
 				"hosted-git-info": {
 					"version": "4.1.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
 					"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
 					"dev": true,
 					"requires": {
@@ -3603,7 +3608,7 @@
 				},
 				"lru-cache": {
 					"version": "6.0.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/lru-cache/-/lru-cache-6.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 					"dev": true,
 					"requires": {
@@ -3612,7 +3617,7 @@
 				},
 				"through2": {
 					"version": "2.0.5",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/through2/-/through2-2.0.5.tgz",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
 					"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
 					"dev": true,
 					"requires": {
@@ -3622,7 +3627,7 @@
 				},
 				"yallist": {
 					"version": "4.0.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/yallist/-/yallist-4.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 					"dev": true
 				}
@@ -3680,7 +3685,7 @@
 		},
 		"git-raw-commits": {
 			"version": "2.0.11",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/git-raw-commits/-/git-raw-commits-2.0.11.tgz",
+			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.11.tgz",
 			"integrity": "sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==",
 			"dev": true,
 			"requires": {
@@ -3693,7 +3698,7 @@
 		},
 		"git-remote-origin-url": {
 			"version": "2.0.0",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
 			"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
 			"dev": true,
 			"requires": {
@@ -3703,7 +3708,7 @@
 			"dependencies": {
 				"pify": {
 					"version": "2.3.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/pify/-/pify-2.3.0.tgz",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 					"dev": true
 				}
@@ -3711,7 +3716,7 @@
 		},
 		"git-semver-tags": {
 			"version": "4.1.1",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/git-semver-tags/-/git-semver-tags-4.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-4.1.1.tgz",
 			"integrity": "sha512-OWyMt5zBe7xFs8vglMmhM9lRQzCWL3WjHtxNNfJTMngGym7pC1kh8sP6jevfydJ6LP3ZvGxfb6ABYgPUM0mtsA==",
 			"dev": true,
 			"requires": {
@@ -3721,7 +3726,7 @@
 			"dependencies": {
 				"semver": {
 					"version": "6.3.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/semver/-/semver-6.3.0.tgz",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				}
@@ -3729,7 +3734,7 @@
 		},
 		"gitconfiglocal": {
 			"version": "1.0.0",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
 			"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
 			"dev": true,
 			"requires": {
@@ -3848,7 +3853,7 @@
 		},
 		"hard-rejection": {
 			"version": "2.1.0",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/hard-rejection/-/hard-rejection-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
 			"integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
 			"dev": true
 		},
@@ -4300,7 +4305,7 @@
 		},
 		"is-obj": {
 			"version": "2.0.0",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/is-obj/-/is-obj-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
 			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
 			"dev": true
 		},
@@ -4399,7 +4404,7 @@
 		},
 		"is-text-path": {
 			"version": "1.0.1",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/is-text-path/-/is-text-path-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
 			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
 			"dev": true,
 			"requires": {
@@ -4504,7 +4509,7 @@
 		},
 		"json-parse-even-better-errors": {
 			"version": "2.3.1",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"dev": true
 		},
@@ -4539,7 +4544,7 @@
 		},
 		"jsonparse": {
 			"version": "1.3.1",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/jsonparse/-/jsonparse-1.3.1.tgz",
+			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
 			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
 			"dev": true
 		},
@@ -4650,7 +4655,7 @@
 		},
 		"lines-and-columns": {
 			"version": "1.2.4",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
 			"dev": true
 		},
@@ -4739,7 +4744,7 @@
 		},
 		"lodash.ismatch": {
 			"version": "4.4.0",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
 			"integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
 			"dev": true
 		},
@@ -4923,7 +4928,7 @@
 		},
 		"map-obj": {
 			"version": "4.3.0",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/map-obj/-/map-obj-4.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
 			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
 			"dev": true
 		},
@@ -4974,7 +4979,7 @@
 		},
 		"meow": {
 			"version": "8.1.2",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/meow/-/meow-8.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
 			"integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
 			"dev": true,
 			"requires": {
@@ -4993,7 +4998,7 @@
 			"dependencies": {
 				"@babel/code-frame": {
 					"version": "7.16.7",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/@babel/code-frame/-/code-frame-7.16.7.tgz",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
 					"integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
 					"dev": true,
 					"requires": {
@@ -5013,7 +5018,7 @@
 				},
 				"find-up": {
 					"version": "4.1.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/find-up/-/find-up-4.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
 					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
 					"dev": true,
 					"requires": {
@@ -5023,7 +5028,7 @@
 				},
 				"hosted-git-info": {
 					"version": "4.1.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
 					"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
 					"dev": true,
 					"requires": {
@@ -5032,13 +5037,13 @@
 				},
 				"js-tokens": {
 					"version": "4.0.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/js-tokens/-/js-tokens-4.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 					"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 					"dev": true
 				},
 				"locate-path": {
 					"version": "5.0.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/locate-path/-/locate-path-5.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
 					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 					"dev": true,
 					"requires": {
@@ -5047,7 +5052,7 @@
 				},
 				"lru-cache": {
 					"version": "6.0.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/lru-cache/-/lru-cache-6.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 					"dev": true,
 					"requires": {
@@ -5056,7 +5061,7 @@
 				},
 				"normalize-package-data": {
 					"version": "3.0.3",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
 					"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
 					"dev": true,
 					"requires": {
@@ -5068,7 +5073,7 @@
 				},
 				"p-limit": {
 					"version": "2.3.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/p-limit/-/p-limit-2.3.0.tgz",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
 					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 					"dev": true,
 					"requires": {
@@ -5077,7 +5082,7 @@
 				},
 				"p-locate": {
 					"version": "4.1.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/p-locate/-/p-locate-4.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
 					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
 					"dev": true,
 					"requires": {
@@ -5086,13 +5091,13 @@
 				},
 				"p-try": {
 					"version": "2.2.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/p-try/-/p-try-2.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
 				"parse-json": {
 					"version": "5.2.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/parse-json/-/parse-json-5.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
 					"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
 					"dev": true,
 					"requires": {
@@ -5104,13 +5109,13 @@
 				},
 				"path-exists": {
 					"version": "4.0.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/path-exists/-/path-exists-4.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 					"dev": true
 				},
 				"read-pkg": {
 					"version": "5.2.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/read-pkg/-/read-pkg-5.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
 					"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
 					"dev": true,
 					"requires": {
@@ -5122,13 +5127,13 @@
 					"dependencies": {
 						"hosted-git-info": {
 							"version": "2.8.9",
-							"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+							"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
 							"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
 							"dev": true
 						},
 						"normalize-package-data": {
 							"version": "2.5.0",
-							"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+							"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
 							"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
 							"dev": true,
 							"requires": {
@@ -5140,13 +5145,13 @@
 						},
 						"semver": {
 							"version": "5.7.1",
-							"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/semver/-/semver-5.7.1.tgz",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 							"dev": true
 						},
 						"type-fest": {
 							"version": "0.6.0",
-							"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/type-fest/-/type-fest-0.6.0.tgz",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
 							"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
 							"dev": true
 						}
@@ -5154,7 +5159,7 @@
 				},
 				"read-pkg-up": {
 					"version": "7.0.1",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
 					"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
 					"dev": true,
 					"requires": {
@@ -5165,7 +5170,7 @@
 					"dependencies": {
 						"type-fest": {
 							"version": "0.8.1",
-							"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/type-fest/-/type-fest-0.8.1.tgz",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
 							"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
 							"dev": true
 						}
@@ -5173,7 +5178,7 @@
 				},
 				"resolve": {
 					"version": "1.22.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/resolve/-/resolve-1.22.0.tgz",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
 					"integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
 					"dev": true,
 					"requires": {
@@ -5184,7 +5189,7 @@
 				},
 				"semver": {
 					"version": "7.3.7",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/semver/-/semver-7.3.7.tgz",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
 					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
 					"dev": true,
 					"requires": {
@@ -5193,7 +5198,7 @@
 				},
 				"yallist": {
 					"version": "4.0.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/yallist/-/yallist-4.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 					"dev": true
 				}
@@ -5269,7 +5274,7 @@
 		},
 		"min-indent": {
 			"version": "1.0.1",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/min-indent/-/min-indent-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
 			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
 			"dev": true
 		},
@@ -5288,7 +5293,7 @@
 		},
 		"minimist-options": {
 			"version": "4.1.0",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/minimist-options/-/minimist-options-4.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
 			"integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
 			"dev": true,
 			"requires": {
@@ -5299,7 +5304,7 @@
 			"dependencies": {
 				"kind-of": {
 					"version": "6.0.3",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/kind-of/-/kind-of-6.0.3.tgz",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
 					"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
 					"dev": true
 				}
@@ -5401,7 +5406,7 @@
 		},
 		"modify-values": {
 			"version": "1.0.1",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/modify-values/-/modify-values-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
 			"integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
 			"dev": true
 		},
@@ -8232,7 +8237,7 @@
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-is-inside": {
@@ -9013,7 +9018,7 @@
 		},
 		"q": {
 			"version": "1.5.1",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/q/-/q-1.5.1.tgz",
+			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
 			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
 			"dev": true
 		},
@@ -9079,7 +9084,7 @@
 		},
 		"quick-lru": {
 			"version": "4.0.1",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/quick-lru/-/quick-lru-4.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
 			"integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
 			"dev": true
 		},
@@ -9119,7 +9124,7 @@
 		},
 		"read-pkg": {
 			"version": "3.0.0",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/read-pkg/-/read-pkg-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 			"dev": true,
 			"requires": {
@@ -9130,7 +9135,7 @@
 			"dependencies": {
 				"load-json-file": {
 					"version": "4.0.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/load-json-file/-/load-json-file-4.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 					"dev": true,
 					"requires": {
@@ -9144,7 +9149,7 @@
 		},
 		"read-pkg-up": {
 			"version": "3.0.0",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 			"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 			"dev": true,
 			"requires": {
@@ -9168,7 +9173,7 @@
 		},
 		"redent": {
 			"version": "3.0.0",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/redent/-/redent-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
 			"integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
 			"dev": true,
 			"requires": {
@@ -9178,7 +9183,7 @@
 			"dependencies": {
 				"indent-string": {
 					"version": "4.0.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/indent-string/-/indent-string-4.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
 					"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
 					"dev": true
 				}
@@ -9394,7 +9399,7 @@
 		},
 		"safe-regex": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"dev": true,
 			"requires": {
@@ -9801,7 +9806,7 @@
 		},
 		"split": {
 			"version": "1.0.1",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/split/-/split-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
 			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
 			"dev": true,
 			"requires": {
@@ -9819,7 +9824,7 @@
 		},
 		"split2": {
 			"version": "3.2.2",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/split2/-/split2-3.2.2.tgz",
+			"resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
 			"integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
 			"dev": true,
 			"requires": {
@@ -9828,7 +9833,7 @@
 			"dependencies": {
 				"readable-stream": {
 					"version": "3.6.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/readable-stream/-/readable-stream-3.6.0.tgz",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
 					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"dev": true,
 					"requires": {
@@ -10082,7 +10087,7 @@
 		},
 		"stringify-package": {
 			"version": "1.0.1",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/stringify-package/-/stringify-package-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.1.tgz",
 			"integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==",
 			"dev": true
 		},
@@ -10102,13 +10107,13 @@
 		},
 		"strip-eof": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 			"dev": true
 		},
 		"strip-indent": {
 			"version": "3.0.0",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/strip-indent/-/strip-indent-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
 			"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
 			"dev": true,
 			"requires": {
@@ -10255,7 +10260,7 @@
 		},
 		"text-extensions": {
 			"version": "1.9.0",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/text-extensions/-/text-extensions-1.9.0.tgz",
+			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
 			"integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
 			"dev": true
 		},
@@ -10272,7 +10277,7 @@
 		},
 		"through2": {
 			"version": "4.0.2",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/through2/-/through2-4.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
 			"integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
 			"dev": true,
 			"requires": {
@@ -10281,7 +10286,7 @@
 			"dependencies": {
 				"readable-stream": {
 					"version": "3.6.0",
-					"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/readable-stream/-/readable-stream-3.6.0.tgz",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
 					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"dev": true,
 					"requires": {
@@ -10377,7 +10382,7 @@
 		},
 		"trim-newlines": {
 			"version": "3.0.1",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/trim-newlines/-/trim-newlines-3.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
 			"integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
 			"dev": true
 		},
@@ -10422,7 +10427,7 @@
 		},
 		"type-fest": {
 			"version": "0.18.1",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/type-fest/-/type-fest-0.18.1.tgz",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
 			"integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
 			"dev": true
 		},
@@ -10437,7 +10442,7 @@
 		},
 		"typedarray": {
 			"version": "0.0.6",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/typedarray/-/typedarray-0.0.6.tgz",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 			"dev": true
 		},
@@ -10857,13 +10862,13 @@
 		},
 		"yargs-parser": {
 			"version": "20.2.9",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
 			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
 			"dev": true
 		},
 		"yocto-queue": {
 			"version": "0.1.0",
-			"resolved": "https://box.jfrog.io/box/api/npm/boxnpm/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
 			"dev": true
 		},

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 	},
 	"bugs": "https://github.com/box/boxcli/issues",
 	"dependencies": {
+		"@discoveryjs/json-ext": "^0.5.7",
 		"@oclif/command": "^1.5.5",
 		"@oclif/config": "^1.7.6",
 		"@oclif/plugin-autocomplete": "^0.1.0",

--- a/src/commands/folders/upload.js
+++ b/src/commands/folders/upload.js
@@ -14,7 +14,7 @@ class FoldersUploadCommand extends BoxCommand {
 
 		let folderId = await this.uploadFolder(args.path, flags['parent-folder'], flags['folder-name']);
 		let folder = await this.client.folders.get(folderId);
-		this.output(folder);
+		await this.output(folder);
 	}
 
 	async uploadFolder(folderPath, parentFolderId, folderName) {


### PR DESCRIPTION
Using json.ext stream instead of json.stringify. I couldn't write any meaningful tests to see if large json works now because I was hitting the heap allocation limit in unit tests under Node 12. It worked on Node 16, so we'll be able to test this with unit tests after the upgrade.

Also added missing await in upload. 