### PR TITLE
fix: Fix request command when calling without body

### DIFF
--- a/src/commands/request.js
+++ b/src/commands/request.js
@@ -17,7 +17,7 @@ class ManualRequestCommand extends BoxCommand {
 			params.qs = querystring.parse(flags.query);
 		}
 
-		if (flags.hasOwnProperty('body')) {
+		if (flags.hasOwnProperty('body') && flags.body !== '') {
 			try {
 				params.body = JSON.parse(flags.body);
 				params.json = true;


### PR DESCRIPTION
Previously, when a user made a request without passing the body parameter,  the `Content-Type` was set to `application/octet-stream`.

This was wrong because there was no content, but for some reasons the backend was accepting it and returning the correct respsone.
Now the backend probably started validating Content-Type header and returns 400 if it's wrong.

To fix that we just need to make sure we set Content-Type to correct value and only if it needed.