### PR TITLE
docs: Add cross links to developer guides

### DIFF
--- a/examples/Inactive Users Report/README.md
+++ b/examples/Inactive Users Report/README.md
@@ -2,6 +2,8 @@
 
 > Due to scale issue, CLI can't handle more than 1M events per run and as a run the Inactive Users Report will fail.
 
+**For detailed script overview, please follow [this guide][user-guide].**
+
 Identifies inactive enterprise users by looking at user activity within a defined period of time. This script helps manage the number of seats within an enterprise and works in synergy with the deprovisioning script.
 
 This script generates a `.csv` file with a list of users who has been inactive for a number of days. It performs the following steps:
@@ -97,3 +99,4 @@ This project is a collection of open source examples and should not be treated a
 [ReportName-param]: /examples/Inactive%20Users%20Report/Inactive_Users_Report.ps1#L11
 [events-param]: /examples/Inactive%20Users%20Report/Inactive_Users_Report.ps1#L17
 [deprovisionscript]: https://developer.box.com/guides/cli/scripts/deprovision-users/
+[user-guide]: https://developer.box.com/guides/cli/scripts/report-inactive-users/

--- a/examples/Mass Groups & Collaborations Update/README.md
+++ b/examples/Mass Groups & Collaborations Update/README.md
@@ -1,4 +1,7 @@
 # Mass Groups & Collaborations Update
+
+**For detailed script overview, please follow [this guide][user-guide].**
+
 Creates and updates collaboration groups,  adds role-based group access to folders.
 The script consists of two parts described in detail in the sections below. You can run them both or use the optional flags to decide which part to run.
 
@@ -45,8 +48,6 @@ In case when you want to skip this part of creating collaborations, you just nee
 
 
 4. Create an OAuth Application using the [CLI Setup Quick Start][oauth-guide].
-
-[oauth-guide]: https://developer.box.com/guides/cli/quick-start/
 
 
 ## 1. Script Parameters
@@ -124,3 +125,6 @@ Logs are stored in a `logs` folder located in the main folder. You have access t
 
 ## Disclaimer
 This project is a collection of open source examples and should not be treated as an officially supported product. Use at your own risk and as a source of example how to use Box CLI.
+
+[oauth-guide]: https://developer.box.com/guides/cli/quick-start/
+[user-guide]: https://developer.box.com/guides/cli/scripts/manage-groups-collaborations/

--- a/examples/Mass Update User Zones/README.md
+++ b/examples/Mass Update User Zones/README.md
@@ -114,4 +114,4 @@ This project is a collection of open source examples and should not be treated a
 [example-csv]: User_Zones_Update.csv
 [zonestable]:/examples/Mass%20Update%20User%20Zones/Mass_Update_User_Zones.ps1#L23
 [adminEmail-param]: /examples/Mass%20Update%20User%20Zones/Mass_Update_User_Zones.ps1#L21
-user-guide]: https://developer.box.com/guides/cli/scripts/user-zones-mass-update/
+[user-guide]: https://developer.box.com/guides/cli/scripts/user-zones-mass-update/

--- a/examples/Mass Update User Zones/README.md
+++ b/examples/Mass Update User Zones/README.md
@@ -1,5 +1,7 @@
 # Mass Update User Zones #
 
+**For detailed script overview, please follow [this guide][user-guide].**
+
 Provisions users to specified data residency Zones within a Multizone Box tenant. It performs the following steps:
 
 1. It uses admin or co-admin login email address to find the associated enterprise and the zone policy assigned to this enterprise. An assigned zone policy is inherited by all users unless specified otherwise. It is sometimes called the **default zone**.
@@ -112,3 +114,4 @@ This project is a collection of open source examples and should not be treated a
 [example-csv]: User_Zones_Update.csv
 [zonestable]:/examples/Mass%20Update%20User%20Zones/Mass_Update_User_Zones.ps1#L23
 [adminEmail-param]: /examples/Mass%20Update%20User%20Zones/Mass_Update_User_Zones.ps1#L21
+user-guide]: https://developer.box.com/guides/cli/scripts/user-zones-mass-update/


### PR DESCRIPTION
Link CLI sample scripts to developer website at https://developer.box.com/guides/cli/scripts/