### PR TITLE
chore: run unit tests on macos and windows

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,6 +11,7 @@ jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node: ['12']
@@ -30,7 +31,7 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: run-node-${{ matrix.node }}
+          flag-name: run-node-${{ matrix.node }}-${{ matrix.os }}
           parallel: true
   finish:
     needs: build-and-test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9,9 +9,10 @@ on:
       - main
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         node: ['12']
     name: Node ${{ matrix.node }}
     steps:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node: ['12']
-    name: Node ${{ matrix.node }}
+    name: Node ${{ matrix.node }} on ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/src/box-command.js
+++ b/src/box-command.js
@@ -900,7 +900,7 @@ class BoxCommand extends Command {
 				},
 			});
 
-			writeFunc = async(savePath) => {
+			writeFunc = async (savePath) => {
 				await pipeline(
 					stringifiedOutput,
 					appendNewLineTransform,
@@ -908,13 +908,13 @@ class BoxCommand extends Command {
 				);
 			};
 
-			logFunc = async() => {
+			logFunc = async () => {
 				await this.logStream(stringifiedOutput);
 			};
 		} else {
 			stringifiedOutput = await this._stringifyOutput(formattedOutputData);
 
-			writeFunc = async(savePath) => {
+			writeFunc = async (savePath) => {
 				await fs.writeFile(savePath, stringifiedOutput + os.EOL, {
 					encoding: 'utf8',
 				});
@@ -1154,7 +1154,7 @@ class BoxCommand extends Command {
 	 */
 	log(content) {
 		if (!this.flags.quiet) {
-			super.log(content);
+			process.stdout.write(`${content}${os.EOL}`);
 		}
 	}
 

--- a/test/box-command.test.js
+++ b/test/box-command.test.js
@@ -8,7 +8,7 @@ const leche = require('leche');
 const { test } = require('@oclif/test');
 const os = require('os');
 const debug = require('debug');
-const { TEST_API_ROOT } = require('./helpers/test-helper');
+const { TEST_API_ROOT, isWin } = require('./helpers/test-helper');
 
 describe('BoxCommand', () => {
 
@@ -29,7 +29,7 @@ describe('BoxCommand', () => {
 			])
 			.it('should enable framework debugging when verbose flag is passed', ctx => {
 				debug.disable();
-				let debugLines = ctx.stderr.split(os.EOL);
+				let debugLines = ctx.stderr.split('\n');
 				assert.include(debugLines[0], 'box:@box/cli:hooks:init');
 				assert.include(debugLines[1], 'box:help');
 			})
@@ -66,7 +66,8 @@ describe('BoxCommand', () => {
 			])
 			.it('should save output to file named with valid characters', ctx => {
 				assert.include(ctx.stderr, 'folders-collaborations-add');
-				assert.notInclude(ctx.stderr, ':');
+				const stderr = isWin() ? ctx.stderr.replace(':', '') : ctx.stderr
+				assert.notInclude(stderr, ':');
 			});
 	});
 

--- a/test/box-command.test.js
+++ b/test/box-command.test.js
@@ -6,7 +6,6 @@ const BoxCommand = require('../src/box-command');
 const sinon = require('sinon');
 const leche = require('leche');
 const { test } = require('@oclif/test');
-const os = require('os');
 const debug = require('debug');
 const { TEST_API_ROOT, isWin } = require('./helpers/test-helper');
 
@@ -66,7 +65,7 @@ describe('BoxCommand', () => {
 			])
 			.it('should save output to file named with valid characters', ctx => {
 				assert.include(ctx.stderr, 'folders-collaborations-add');
-				const stderr = isWin() ? ctx.stderr.replace(':', '') : ctx.stderr
+				const stderr = isWin() ? ctx.stderr.replace(':', '') : ctx.stderr;
 				assert.notInclude(stderr, ':');
 			});
 	});

--- a/test/commands/collaborations.test.js
+++ b/test/commands/collaborations.test.js
@@ -58,8 +58,8 @@ describe('Collaborations', () => {
 				'--token=test'
 			])
 			.it('should send fields param and filter output when --fields flag is passed', ctx => {
-				let lb = os.EOL;
-				assert.equal(ctx.stdout, `Type: collaboration${lb}ID: '1234567890'${lb}Status: accepted${lb}Role: editor${lb}`);
+				let lb = "\n";
+				assert.equal(ctx.stdout, `Type: collaboration${lb}ID: '1234567890'${lb}Status: accepted${lb}Role: editor${os.EOL}`);
 			});
 	});
 
@@ -211,8 +211,8 @@ describe('Collaborations', () => {
 					'--token=test'
 				])
 				.it('should send fields param and filter output when --fields flag is passed', ctx => {
-					let lb = os.EOL;
-					assert.equal(ctx.stdout, `Type: collaboration${lb}ID: '1234567890'${lb}Status: accepted${lb}Role: viewer${lb}`);
+					let lb = "\n";
+					assert.equal(ctx.stdout, `Type: collaboration${lb}ID: '1234567890'${lb}Status: accepted${lb}Role: viewer${os.EOL}`);
 				});
 
 			leche.withData({
@@ -491,8 +491,8 @@ describe('Collaborations', () => {
 					'--token=test'
 				])
 				.it('should send fields param and filter output when --fields flag is passed', ctx => {
-					let lb = os.EOL;
-					assert.equal(ctx.stdout, `Type: collaboration${lb}ID: '1234567890'${lb}Status: accepted${lb}Role: previewer${lb}`);
+					let lb = "\n";
+					assert.equal(ctx.stdout, `Type: collaboration${lb}ID: '1234567890'${lb}Status: accepted${lb}Role: previewer${os.EOL}`);
 				});
 
 			leche.withData({

--- a/test/commands/files.test.js
+++ b/test/commands/files.test.js
@@ -1828,7 +1828,7 @@ describe('Files', () => {
 
 	describe('files:download', () => {
 		// download tests are hanging indefinitely on windows
-		if(!isWin()) {
+		if (!isWin()) {
 			let fileId = '12345',
 				fileName = 'test_file_download.txt',
 				saveAsFileName = 'new_file_name.txt',

--- a/test/commands/files.test.js
+++ b/test/commands/files.test.js
@@ -2071,7 +2071,7 @@ describe('Files', () => {
 				})
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
-				.get(toUrlPath(fileDownloadUrl))
+				.get(fileDownloadUrl)
 				.reply(200, function() { return fs.createReadStream(testFilePath, 'utf8'); })
 			)
 			.stdout()

--- a/test/commands/files.test.js
+++ b/test/commands/files.test.js
@@ -4,7 +4,8 @@ const { test } = require('@oclif/test');
 const assert = require('chai').assert;
 const fs = require('fs');
 const path = require('path');
-const { getFixture, TEST_API_ROOT, TEST_UPLOAD_ROOT, TEST_DOWNLOAD_ROOT, DEFAULT_DOWNLOAD_PATH, getDownloadProgressBar, isWin } = require('../helpers/test-helper');
+const { getFixture, TEST_API_ROOT, TEST_UPLOAD_ROOT, TEST_DOWNLOAD_ROOT,
+	DEFAULT_DOWNLOAD_PATH, getDownloadProgressBar, isWin, toUrlPath } = require('../helpers/test-helper');
 const os = require('os');
 const leche = require('leche');
 
@@ -2055,6 +2056,7 @@ describe('Files', () => {
 			fileVersionID = '8764569',
 			testFilePath = path.join(__dirname, '..', 'fixtures/files/epic-poem.txt'),
 			fileDownloadPath = path.join(__dirname, '..', 'fixtures/files'),
+			fileDownloadUrl = toUrlPath(fileDownloadPath),
 			destinationPath = `${fileDownloadPath}/temp`,
 			getFileFixture = getFixture('files/get_files_id');
 
@@ -2065,11 +2067,11 @@ describe('Files', () => {
 				.get(`/2.0/files/${fileId}/content`)
 				.query({ version: fileVersionID })
 				.reply(302, '', {
-					Location: TEST_DOWNLOAD_ROOT + fileDownloadPath
+					Location: TEST_DOWNLOAD_ROOT + fileDownloadUrl
 				})
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
-				.get(fileDownloadPath)
+				.get(toUrlPath(fileDownloadUrl))
 				.reply(200, function() { return fs.createReadStream(testFilePath, 'utf8'); })
 			)
 			.stdout()
@@ -2090,7 +2092,7 @@ describe('Files', () => {
 				fs.unlinkSync(downloadedFilePath);
 				/* eslint-enable no-sync */
 				assert.ok(downloadContent.equals(expectedContent));
-				assert.equal(ctx.stderr, 'Downloaded file test_file_download.txt\n');
+				assert.equal(ctx.stderr, `Downloaded file test_file_download.txt${os.EOL}`);
 			});
 
 		test
@@ -2100,11 +2102,11 @@ describe('Files', () => {
 				.get(`/2.0/files/${fileId}/content`)
 				.query({ version: fileVersionID })
 				.reply(302, '', {
-					Location: TEST_DOWNLOAD_ROOT + fileDownloadPath
+					Location: TEST_DOWNLOAD_ROOT + fileDownloadUrl
 				})
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
-				.get(fileDownloadPath)
+				.get(fileDownloadUrl)
 				.reply(200, function() { return fs.createReadStream(testFilePath, 'utf8'); })
 			)
 			.stdout()
@@ -2125,7 +2127,7 @@ describe('Files', () => {
 				fs.unlinkSync(downloadedFilePath);
 				/* eslint-enable no-sync */
 				assert.ok(downloadContent.equals(expectedContent));
-				assert.equal(ctx.stderr, 'Downloaded file test_file_download.txt\n');
+				assert.equal(ctx.stderr, `Downloaded file test_file_download.txt${os.EOL}`);
 			});
 
 		test
@@ -2135,11 +2137,11 @@ describe('Files', () => {
 				.get(`/2.0/files/${fileId}/content`)
 				.query({ version: fileVersionID })
 				.reply(302, '', {
-					Location: TEST_DOWNLOAD_ROOT + fileDownloadPath
+					Location: TEST_DOWNLOAD_ROOT + fileDownloadUrl
 				})
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
-				.get(fileDownloadPath)
+				.get(fileDownloadUrl)
 				.reply(200, function() { return fs.createReadStream(testFilePath, 'utf8'); })
 			)
 			.stdout()
@@ -2168,11 +2170,11 @@ describe('Files', () => {
 				.get(`/2.0/files/${fileId}/content`)
 				.query({ version: fileVersionID })
 				.reply(302, '', {
-					Location: TEST_DOWNLOAD_ROOT + fileDownloadPath
+					Location: TEST_DOWNLOAD_ROOT + fileDownloadUrl
 				})
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
-				.get(fileDownloadPath)
+				.get(fileDownloadUrl)
 				.reply(200, function() { return fs.createReadStream(testFilePath, 'utf8'); })
 			)
 			.stdout()
@@ -2203,11 +2205,11 @@ describe('Files', () => {
 				.get(`/2.0/files/${fileId}/content`)
 				.query({ version: fileVersionID })
 				.reply(302, '', {
-					Location: TEST_DOWNLOAD_ROOT + fileDownloadPath
+					Location: TEST_DOWNLOAD_ROOT + fileDownloadUrl
 				})
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
-				.get(fileDownloadPath)
+				.get(fileDownloadUrl)
 				.reply(200, function() { return fs.createReadStream(testFilePath, 'utf8'); })
 			)
 			.stdout()
@@ -2239,11 +2241,11 @@ describe('Files', () => {
 				.get(`/2.0/files/${fileId}/content`)
 				.query({ version: fileVersionID })
 				.reply(302, '', {
-					Location: TEST_DOWNLOAD_ROOT + fileDownloadPath
+					Location: TEST_DOWNLOAD_ROOT + fileDownloadUrl
 				})
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
-				.get(fileDownloadPath)
+				.get(fileDownloadUrl)
 				.reply(200, function() { return fs.createReadStream(testFilePath, 'utf8'); })
 			)
 			.do(() => {

--- a/test/commands/files.test.js
+++ b/test/commands/files.test.js
@@ -1828,28 +1828,27 @@ describe('Files', () => {
 	});
 
 	describe('files:download', () => {
-		// download tests are hanging indefinitely on windows
-		if (!isWin()) {
-			let fileId = '12345',
-				fileName = 'test_file_download.txt',
-				saveAsFileName = 'new_file_name.txt',
-				fileVersionID = '8764569',
-				testFilePath = path.join(__dirname, '..', 'fixtures/files/epic-poem.txt'),
-				fileDownloadPath = path.join(__dirname, '..', 'fixtures/files'),
-				destinationPath = `${fileDownloadPath}/temp`,
-				getFileFixture = getFixture('files/get_files_id');
+		let fileId = '12345',
+		fileName = 'test_file_download.txt',
+		saveAsFileName = 'new_file_name.txt',
+		fileVersionID = '8764569',
+		testFilePath = path.join(__dirname, '..', 'fixtures/files/epic-poem.txt'),
+		fileDownloadPath = path.join(__dirname, '..', 'fixtures/files'),
+		fileDownloadUrl = toUrlPath(fileDownloadPath),
+		destinationPath = path.join(fileDownloadPath, 'temp'),
+		getFileFixture = getFixture('files/get_files_id');
 
-			test
+		test
 			.nock(TEST_API_ROOT, api => api
 				.get(`/2.0/files/${fileId}`)
 				.reply(200, getFileFixture)
 				.get(`/2.0/files/${fileId}/content`)
 				.reply(302, '', {
-					Location: TEST_DOWNLOAD_ROOT + fileDownloadPath
+					Location: TEST_DOWNLOAD_ROOT + fileDownloadUrl
 				})
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
-				.get(fileDownloadPath)
+				.get(fileDownloadUrl)
 				.reply(200, function() { return fs.createReadStream(testFilePath, 'utf8'); })
 			)
 			.stdout()
@@ -1880,11 +1879,11 @@ describe('Files', () => {
 				.reply(200, getFileFixture)
 				.get(`/2.0/files/${fileId}/content`)
 				.reply(302, '', {
-					Location: TEST_DOWNLOAD_ROOT + fileDownloadPath
+					Location: TEST_DOWNLOAD_ROOT + fileDownloadUrl
 				})
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
-				.get(fileDownloadPath)
+				.get(fileDownloadUrl)
 				.reply(200, function() { return fs.createReadStream(testFilePath, 'utf8'); })
 			)
 			.stdout()
@@ -1913,11 +1912,11 @@ describe('Files', () => {
 				.reply(200, getFileFixture)
 				.get(`/2.0/files/${fileId}/content`)
 				.reply(302, '', {
-					Location: TEST_DOWNLOAD_ROOT + fileDownloadPath
+					Location: TEST_DOWNLOAD_ROOT + fileDownloadUrl
 				})
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
-				.get(fileDownloadPath)
+				.get(fileDownloadUrl)
 				.reply(200, function() { return fs.createReadStream(testFilePath, 'utf8'); })
 			)
 			.stdout()
@@ -1944,11 +1943,11 @@ describe('Files', () => {
 				.reply(200, getFileFixture)
 				.get(`/2.0/files/${fileId}/content`)
 				.reply(302, '', {
-					Location: TEST_DOWNLOAD_ROOT + fileDownloadPath
+					Location: TEST_DOWNLOAD_ROOT + fileDownloadUrl
 				})
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
-				.get(fileDownloadPath)
+				.get(fileDownloadUrl)
 				.reply(200, function() { return fs.createReadStream(testFilePath, 'utf8'); })
 			)
 			.stdout()
@@ -1978,11 +1977,11 @@ describe('Files', () => {
 				.reply(200, getFileFixture)
 				.get(`/2.0/files/${fileId}/content`)
 				.reply(302, '', {
-					Location: TEST_DOWNLOAD_ROOT + fileDownloadPath
+					Location: TEST_DOWNLOAD_ROOT + fileDownloadUrl
 				})
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
-				.get(fileDownloadPath)
+				.get(fileDownloadUrl)
 				.reply(200, function() { return fs.createReadStream(testFilePath, 'utf8'); })
 			)
 			.do(() => {
@@ -2016,11 +2015,11 @@ describe('Files', () => {
 				.get(`/2.0/files/${fileId}/content`)
 				.query({ version: fileVersionID })
 				.reply(302, '', {
-					Location: TEST_DOWNLOAD_ROOT + fileDownloadPath
+					Location: TEST_DOWNLOAD_ROOT + fileDownloadUrl
 				})
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
-				.get(fileDownloadPath)
+				.get(fileDownloadUrl)
 				.reply(200, function() { return fs.createReadStream(testFilePath, 'utf8'); })
 			)
 			.stdout()
@@ -2045,7 +2044,6 @@ describe('Files', () => {
 				expectedMessage += `Downloaded file test_file_download.txt${os.EOL}`;
 				assert.equal(ctx.stderr, expectedMessage);
 			});
-		}
 	});
 
 	describe('files:versions:download', () => {
@@ -2057,7 +2055,7 @@ describe('Files', () => {
 			testFilePath = path.join(__dirname, '..', 'fixtures/files/epic-poem.txt'),
 			fileDownloadPath = path.join(__dirname, '..', 'fixtures/files'),
 			fileDownloadUrl = toUrlPath(fileDownloadPath),
-			destinationPath = `${fileDownloadPath}/temp`,
+			destinationPath = path.join(fileDownloadPath, 'temp'),
 			getFileFixture = getFixture('files/get_files_id');
 
 		test
@@ -2332,7 +2330,7 @@ describe('Files', () => {
 				assert.equal(ctx.stdout, downloadStatusFixture);
 			});
 
-		const destination = `${fileDownloadPath}/temp`;
+		const destination = path.join(fileDownloadPath, 'temp');
 
 		test
 			.nock(TEST_API_ROOT, api => api

--- a/test/commands/files.test.js
+++ b/test/commands/files.test.js
@@ -4,7 +4,7 @@ const { test } = require('@oclif/test');
 const assert = require('chai').assert;
 const fs = require('fs');
 const path = require('path');
-const { getFixture, TEST_API_ROOT, TEST_UPLOAD_ROOT, TEST_DOWNLOAD_ROOT, DEFAULT_DOWNLOAD_PATH, getDownloadProgressBar } = require('../helpers/test-helper');
+const { getFixture, TEST_API_ROOT, TEST_UPLOAD_ROOT, TEST_DOWNLOAD_ROOT, DEFAULT_DOWNLOAD_PATH, getDownloadProgressBar, isWin } = require('../helpers/test-helper');
 const os = require('os');
 const leche = require('leche');
 
@@ -1828,7 +1828,7 @@ describe('Files', () => {
 
 	describe('files:download', () => {
 		// download tests are hanging indefinitely on windows
-		if(process.platform !== "win32") {
+		if(!isWin()) {
 			let fileId = '12345',
 				fileName = 'test_file_download.txt',
 				saveAsFileName = 'new_file_name.txt',

--- a/test/commands/files.test.js
+++ b/test/commands/files.test.js
@@ -1835,8 +1835,16 @@ describe('Files', () => {
 		testFilePath = path.join(__dirname, '..', 'fixtures/files/epic-poem.txt'),
 		fileDownloadPath = path.join(__dirname, '..', 'fixtures/files'),
 		fileDownloadUrl = toUrlPath(fileDownloadPath),
-		destinationPath = path.join(fileDownloadPath, 'temp'),
+		tempDestinationPath = path.join(fileDownloadPath, 'filesTemp'),
+		tempDestinationPath2 = path.join(fileDownloadPath, 'filesTemp2'),
 		getFileFixture = getFixture('files/get_files_id');
+
+		after(() => {
+			/* eslint-disable no-sync */
+			fs.rmdirSync(tempDestinationPath);
+			fs.rmdirSync(tempDestinationPath2);
+			/* eslint-enable no-sync */
+		});
 
 		test
 			.nock(TEST_API_ROOT, api => api
@@ -1891,17 +1899,16 @@ describe('Files', () => {
 			.command([
 				'files:download',
 				fileId,
-				`--destination=${destinationPath}`,
+				`--destination=${tempDestinationPath}`,
 				'-y',
 				'--token=test'
 			])
 			.it('should download a file to a non-existing destination', () => {
 				/* eslint-disable no-sync */
-				let downloadedFilePath = path.join(destinationPath, fileName);
+				let downloadedFilePath = path.join(tempDestinationPath, fileName);
 				let downloadContent = fs.readFileSync(downloadedFilePath);
 				let expectedContent = fs.readFileSync(testFilePath);
 				fs.unlinkSync(downloadedFilePath);
-				fs.rmdirSync(destinationPath);
 				/* eslint-enable no-sync */
 				assert.ok(downloadContent.equals(expectedContent));
 			});
@@ -1956,17 +1963,16 @@ describe('Files', () => {
 				'files:download',
 				fileId,
 				`--save-as=${saveAsFileName}`,
-				`--destination=${destinationPath}`,
+				`--destination=${tempDestinationPath2}`,
 				'-y',
 				'--token=test'
 			])
 			.it('should save downloaded file using provided filename in save-as parameter', () => {
 				/* eslint-disable no-sync */
-				let downloadedFilePath = path.join(destinationPath, saveAsFileName);
+				let downloadedFilePath = path.join(tempDestinationPath2, saveAsFileName);
 				let downloadContent = fs.readFileSync(downloadedFilePath);
 				let expectedContent = fs.readFileSync(testFilePath);
 				fs.unlinkSync(downloadedFilePath);
-				fs.rmdirSync(destinationPath);
 				/* eslint-enable no-sync */
 				assert.ok(downloadContent.equals(expectedContent));
 			});
@@ -2047,7 +2053,6 @@ describe('Files', () => {
 	});
 
 	describe('files:versions:download', () => {
-
 		let fileId = '12345',
 			fileName = 'test_file_download.txt',
 			saveAsFileName = 'new_file_name.txt',
@@ -2055,8 +2060,16 @@ describe('Files', () => {
 			testFilePath = path.join(__dirname, '..', 'fixtures/files/epic-poem.txt'),
 			fileDownloadPath = path.join(__dirname, '..', 'fixtures/files'),
 			fileDownloadUrl = toUrlPath(fileDownloadPath),
-			destinationPath = path.join(fileDownloadPath, 'temp'),
+			tempDestinationPath = path.join(fileDownloadPath, 'versionsTemp'),
+			tempDestinationPath2 = path.join(fileDownloadPath, 'versionsTemp2'),
 			getFileFixture = getFixture('files/get_files_id');
+
+		after(() => {
+			/* eslint-disable no-sync */
+			fs.rmdirSync(tempDestinationPath);
+			fs.rmdirSync(tempDestinationPath2);
+			/* eslint-enable no-sync */
+		});
 
 		test
 			.nock(TEST_API_ROOT, api => api
@@ -2180,18 +2193,17 @@ describe('Files', () => {
 			.command([
 				'files:versions:download',
 				fileId,
-				`--destination=${destinationPath}`,
+				`--destination=${tempDestinationPath}`,
 				'-y',
 				fileVersionID,
 				'--token=test'
 			])
 			.it('should download a file version to a non-existing destination', () => {
 				/* eslint-disable no-sync */
-				let downloadedFilePath = path.join(destinationPath, fileName);
+				let downloadedFilePath = path.join(tempDestinationPath, fileName);
 				let downloadContent = fs.readFileSync(downloadedFilePath);
 				let expectedContent = fs.readFileSync(testFilePath);
 				fs.unlinkSync(downloadedFilePath);
-				fs.rmdirSync(destinationPath);
 				/* eslint-enable no-sync */
 				assert.ok(downloadContent.equals(expectedContent));
 			});
@@ -2216,18 +2228,17 @@ describe('Files', () => {
 				'files:versions:download',
 				fileId,
 				`--save-as=${saveAsFileName}`,
-				`--destination=${destinationPath}`,
+				`--destination=${tempDestinationPath2}`,
 				'-y',
 				fileVersionID,
 				'--token=test'
 			])
 			.it('should save downloaded file version using provided filename in save-as parameter', () => {
 				/* eslint-disable no-sync */
-				let downloadedFilePath = path.join(destinationPath, saveAsFileName);
+				let downloadedFilePath = path.join(tempDestinationPath2, saveAsFileName);
 				let downloadContent = fs.readFileSync(downloadedFilePath);
 				let expectedContent = fs.readFileSync(testFilePath);
 				fs.unlinkSync(downloadedFilePath);
-				fs.rmdirSync(destinationPath);
 				/* eslint-enable no-sync */
 				assert.ok(downloadContent.equals(expectedContent));
 			});

--- a/test/commands/files.test.js
+++ b/test/commands/files.test.js
@@ -5,7 +5,7 @@ const assert = require('chai').assert;
 const fs = require('fs');
 const path = require('path');
 const { getFixture, TEST_API_ROOT, TEST_UPLOAD_ROOT, TEST_DOWNLOAD_ROOT,
-	DEFAULT_DOWNLOAD_PATH, getDownloadProgressBar, isWin, toUrlPath } = require('../helpers/test-helper');
+	DEFAULT_DOWNLOAD_PATH, getDownloadProgressBar, toUrlPath } = require('../helpers/test-helper');
 const os = require('os');
 const leche = require('leche');
 

--- a/test/commands/files.test.js
+++ b/test/commands/files.test.js
@@ -1827,16 +1827,18 @@ describe('Files', () => {
 	});
 
 	describe('files:download', () => {
-		let fileId = '12345',
-			fileName = 'test_file_download.txt',
-			saveAsFileName = 'new_file_name.txt',
-			fileVersionID = '8764569',
-			testFilePath = path.join(__dirname, '..', 'fixtures/files/epic-poem.txt'),
-			fileDownloadPath = path.join(__dirname, '..', 'fixtures/files'),
-			destinationPath = `${fileDownloadPath}/temp`,
-			getFileFixture = getFixture('files/get_files_id');
+		// download tests are hanging indefinitely on windows
+		if(process.platform !== "win32") {
+			let fileId = '12345',
+				fileName = 'test_file_download.txt',
+				saveAsFileName = 'new_file_name.txt',
+				fileVersionID = '8764569',
+				testFilePath = path.join(__dirname, '..', 'fixtures/files/epic-poem.txt'),
+				fileDownloadPath = path.join(__dirname, '..', 'fixtures/files'),
+				destinationPath = `${fileDownloadPath}/temp`,
+				getFileFixture = getFixture('files/get_files_id');
 
-		test
+			test
 			.nock(TEST_API_ROOT, api => api
 				.get(`/2.0/files/${fileId}`)
 				.reply(200, getFileFixture)
@@ -2042,6 +2044,7 @@ describe('Files', () => {
 				expectedMessage += `Downloaded file test_file_download.txt${os.EOL}`;
 				assert.equal(ctx.stderr, expectedMessage);
 			});
+		}
 	});
 
 	describe('files:versions:download', () => {

--- a/test/commands/folders.test.js
+++ b/test/commands/folders.test.js
@@ -4,7 +4,7 @@ const { test } = require('@oclif/test');
 const assert = require('chai').assert;
 const fs = require('fs-extra');
 const path = require('path');
-const { getFixture, TEST_API_ROOT, TEST_UPLOAD_ROOT, TEST_DOWNLOAD_ROOT, DEFAULT_DOWNLOAD_PATH } = require('../helpers/test-helper');
+const { getFixture, TEST_API_ROOT, TEST_UPLOAD_ROOT, TEST_DOWNLOAD_ROOT, DEFAULT_DOWNLOAD_PATH, getDriveLetter, isWin } = require('../helpers/test-helper');
 const os = require('os');
 const leche = require('leche');
 const _ = require('lodash');
@@ -1666,9 +1666,13 @@ describe('Folders', () => {
 				'--no-create-path'
 			])
 			.it('should output error when destination directory does not exist', ctx => {
+				const path = isWin() 
+					? `${getDriveLetter()}\\path\\really\\should\\not\\exist`
+					: '/path/really/should/not/exist'
+
 				assert.equal(
 					ctx.stderr,
-					`The /path/really/should/not/exist path does not exist. Either create it, or pass the --create-path flag set to true${os.EOL}`
+					`The ${path} path does not exist. Either create it, or pass the --create-path flag set to true${os.EOL}`
 				);
 			});
 

--- a/test/commands/folders.test.js
+++ b/test/commands/folders.test.js
@@ -1666,13 +1666,13 @@ describe('Folders', () => {
 				'--no-create-path'
 			])
 			.it('should output error when destination directory does not exist', ctx => {
-				const path = isWin() 
+				const filePath = isWin()
 					? `${getDriveLetter()}\\path\\really\\should\\not\\exist`
-					: '/path/really/should/not/exist'
+					: '/path/really/should/not/exist';
 
 				assert.equal(
 					ctx.stderr,
-					`The ${path} path does not exist. Either create it, or pass the --create-path flag set to true${os.EOL}`
+					`The ${filePath} path does not exist. Either create it, or pass the --create-path flag set to true${os.EOL}`
 				);
 			});
 

--- a/test/commands/request.test.js
+++ b/test/commands/request.test.js
@@ -54,8 +54,8 @@ describe('Manual Request', () => {
 				'--token=test'
 			])
 			.it('should make simple GET request when resource given as path (YAML Output)', ctx => {
-
-				let expectedOutput = `Status Code: 200${os.EOL}Headers: {}${os.EOL}Body: {}${os.EOL}`;
+				let lb = "\n"
+				let expectedOutput = `Status Code: 200${lb}Headers: {}${lb}Body: {}${os.EOL}`;
 
 				assert.equal(ctx.stdout, expectedOutput);
 			});

--- a/test/helpers/test-helper.js
+++ b/test/helpers/test-helper.js
@@ -8,19 +8,31 @@ const TEST_API_ROOT = 'https://api.box.com';
 const TEST_UPLOAD_ROOT = 'https://upload.box.com/api';
 const TEST_DOWNLOAD_ROOT = 'https://dl.boxcloud.com';
 const DEFAULT_DOWNLOAD_PATH = path.join(
-				os.homedir(),
-				'Downloads/Box-Downloads'
-)
+	os.homedir(),
+	'Downloads/Box-Downloads'
+);
 
 function getFixture(fixture) {
 	if (!path.extname(fixture)) {
 		fixture += '.json';
 	}
 	/* eslint-disable no-sync */
-	return fs.readFileSync(
+	const content = fs.readFileSync(
 		path.join(__dirname, '..', `fixtures/${fixture}`),
 		'utf8'
 	);
+
+	if (process.platform === 'win32') {
+		/* eslint-disable require-unicode-regexp */
+		let transformedContent = fixture.endsWith('table.txt')
+			? content.replace(/(?<!-)(?<!\r\n)\r(?!\n\r)/g, '')
+			: content.replace(/\r/g, '');
+		/* eslint-disable require-unicode-regexp */
+
+		return transformedContent.trimEnd().concat(os.EOL);
+	}
+
+	return content;
 	/* eslint-enable no-sync */
 }
 
@@ -30,13 +42,13 @@ function getProgressBar(message) {
 
 function getBulkProgressBar(size) {
 	return getProgressBar(
-		`[----------------------------------------] 0% | 0/${size}[========================================] 100% | ${size}/${size}${os.EOL}`
+		`[----------------------------------------] 0% | 0/${size}[========================================] 100% | ${size}/${size}\n`
 	);
 }
 
 function getDownloadProgressBar(size) {
 	return getProgressBar(
-		`[----------------------------------------] 0% | ETA: 0s | 0/${size} | Speed: N/A MB/s[========================================] 100% | ETA: 0s | ${size}/${size} | Speed: N/A MB/s${os.EOL}`
+		`[----------------------------------------] 0% | ETA: 0s | 0/${size} | Speed: N/A MB/s[========================================] 100% | ETA: 0s | ${size}/${size} | Speed: N/A MB/s\n`
 	);
 }
 

--- a/test/helpers/test-helper.js
+++ b/test/helpers/test-helper.js
@@ -60,6 +60,12 @@ function getDriveLetter() {
 	return process.cwd().split('\\')[0];
 }
 
+function toUrlPath(filePath) {
+	return isWin()
+		? `/${filePath.replace(':', '').replace(/\\/g, '/')}`
+		: filePath;
+}
+
 module.exports = {
 	TEST_API_ROOT,
 	TEST_UPLOAD_ROOT,
@@ -69,5 +75,6 @@ module.exports = {
 	getBulkProgressBar,
 	getDownloadProgressBar,
 	getDriveLetter,
-	isWin
+	isWin,
+	toUrlPath
 };

--- a/test/helpers/test-helper.js
+++ b/test/helpers/test-helper.js
@@ -8,8 +8,8 @@ const TEST_API_ROOT = 'https://api.box.com';
 const TEST_UPLOAD_ROOT = 'https://upload.box.com/api';
 const TEST_DOWNLOAD_ROOT = 'https://dl.boxcloud.com';
 const DEFAULT_DOWNLOAD_PATH = path.join(
-	os.homedir(),
-	'Downloads/Box-Downloads'
+				os.homedir(),
+				'Downloads/Box-Downloads'
 );
 
 function getFixture(fixture) {
@@ -22,10 +22,10 @@ function getFixture(fixture) {
 		'utf8'
 	);
 
-	if (process.platform === 'win32') {
+	if (isWin()) {
 		/* eslint-disable require-unicode-regexp */
-		let transformedContent = fixture.endsWith('table.txt')
-			? content.replace(/(?<!-)(?<!\r\n)\r(?!\n\r)/g, '')
+		let transformedContent = fixture.endsWith('table.txt') 
+			? content.replace(/(?<!-)(?<!\r\n)\r(?!\n\r)/g, '') 
 			: content.replace(/\r/g, '');
 		/* eslint-disable require-unicode-regexp */
 
@@ -52,6 +52,14 @@ function getDownloadProgressBar(size) {
 	);
 }
 
+function getDriveLetter() {
+	return os.homedir().split("\\")[0];
+}
+
+function isWin() {
+	return process.platform === 'win32';
+}
+
 module.exports = {
 	TEST_API_ROOT,
 	TEST_UPLOAD_ROOT,
@@ -60,4 +68,6 @@ module.exports = {
 	getFixture,
 	getBulkProgressBar,
 	getDownloadProgressBar,
+	getDriveLetter,
+	isWin
 };

--- a/test/helpers/test-helper.js
+++ b/test/helpers/test-helper.js
@@ -57,7 +57,7 @@ function getDownloadProgressBar(size) {
 }
 
 function getDriveLetter() {
-	return os.homedir().split('\\')[0];
+	return process.cwd().split('\\')[0];
 }
 
 module.exports = {

--- a/test/helpers/test-helper.js
+++ b/test/helpers/test-helper.js
@@ -12,6 +12,10 @@ const DEFAULT_DOWNLOAD_PATH = path.join(
 				'Downloads/Box-Downloads'
 );
 
+function isWin() {
+	return process.platform === 'win32';
+}
+
 function getFixture(fixture) {
 	if (!path.extname(fixture)) {
 		fixture += '.json';
@@ -24,8 +28,8 @@ function getFixture(fixture) {
 
 	if (isWin()) {
 		/* eslint-disable require-unicode-regexp */
-		let transformedContent = fixture.endsWith('table.txt') 
-			? content.replace(/(?<!-)(?<!\r\n)\r(?!\n\r)/g, '') 
+		let transformedContent = fixture.endsWith('table.txt')
+			? content.replace(/(?<!-)(?<!\r\n)\r(?!\n\r)/g, '')
 			: content.replace(/\r/g, '');
 		/* eslint-disable require-unicode-regexp */
 
@@ -53,11 +57,7 @@ function getDownloadProgressBar(size) {
 }
 
 function getDriveLetter() {
-	return os.homedir().split("\\")[0];
-}
-
-function isWin() {
-	return process.platform === 'win32';
+	return os.homedir().split('\\')[0];
 }
 
 module.exports = {

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -8,6 +8,8 @@ const sinon = require('sinon');
 const process = require('process');
 const fs = require('fs');
 const chaiAsPromised = require('chai-as-promised');
+const os = require('os');
+const { getDriveLetter, isWin } = require('./helpers/test-helper');
 
 chai.use(chaiAsPromised);
 
@@ -19,6 +21,10 @@ describe('Utilities', () => {
 
 	let mockOS,
 		cliUtils;
+
+	const isWindows = isWin()
+	
+	const driveLetter = isWindows ? getDriveLetter() : ''
 
 	beforeEach(() => {
 		mockery.enable({
@@ -45,65 +51,65 @@ describe('Utilities', () => {
 	describe('parsePath()', () => {
 
 		leche.withData({
-			'bare tilde': [
+ 			'bare tilde': [
 				'~',
-				'/home/user'
+				...isWindows ? [`${driveLetter}\\home\\user`] : ['/home/user']
 			],
-			'subdirectory of tilde': [
+ 			'subdirectory of tilde': [
 				'~/foo/bar',
-				'/home/user/foo/bar'
+				...isWindows ? [`${driveLetter}\\home\\user\\foo\\bar`] : ['/home/user/foo/bar']
 			],
 			'absolute path with interior tilde': [
 				'/var/~/bar',
-				'/var/~/bar'
+				...isWindows ? [`${driveLetter}\\var\\~\\bar`] : ['/var/~/bar']
 			],
 			'relative path with interior tilde': [
 				'./~/bar',
-				`${process.cwd()}/~/bar`
+				...isWindows ? [`${process.cwd()}\\~\\bar`] : [`${process.cwd()}/~/bar`]
 			],
 			'absolute path': [
 				'/var/box/files',
-				'/var/box/files'
+				...isWindows ? [`${driveLetter}\\var\\box\\files`] : ['/var/box/files']
 			],
 			'relative path': [
 				'./foo',
-				`${process.cwd()}/foo`
+				...isWindows ? [`${process.cwd()}\\foo`] : [`${process.cwd()}/foo`]
 			],
 			'root directory': [
 				'/',
-				'/'
+				...isWindows ? [`${driveLetter}\\`] : ['/']
 			],
 			'relative path that REALLY should be the root': [
 				'../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../..',
-				'/'
+				...isWindows ? [`${driveLetter}\\`] : ['/']
 			],
 			'absolute file path': [
 				'/foo/bar/doc.pdf',
-				'/foo/bar/doc.pdf'
+				...isWindows ? [`${driveLetter}\\foo\\bar\\doc.pdf`] : ['/foo/bar/doc.pdf']
 			],
 			'relative file path': [
 				'./pic.jpg',
-				`${process.cwd()}/pic.jpg`
+				...isWindows ? [`${process.cwd()}\\pic.jpg`] : [`${process.cwd()}/pic.jpg`]
 			],
 			'file in current directory': [
 				'essay.docx',
-				`${process.cwd()}/essay.docx`
+				...isWindows ? [`${process.cwd()}\\essay.docx`] : [`${process.cwd()}/essay.docx`]
 			],
 			'relative file path that REALLY should be in the root directory': [
 				'../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../../a.txt',
-				'/a.txt'
+				...isWindows ? [`${driveLetter}\\a.txt`] : ['/a.txt']
 			],
 			'folder name with spaces in it': [
 				'/A/Folder/With/Spaces In It',
-				'/A/Folder/With/Spaces In It'
+				...isWindows ? [`${driveLetter}\\A\\Folder\\With\\Spaces In It`] : ['/A/Folder/With/Spaces In It']
 			],
 			'file name with spaces in it': [
 				'/home/otheruser/Secret Stuff.pdf',
-				'/home/otheruser/Secret Stuff.pdf'
+				...isWindows ? [`${driveLetter}\\home\\otheruser\\Secret Stuff.pdf`] : ['/home/otheruser/Secret Stuff.pdf']
 			],
 			'absolute path to folder with trailing slash': [
 				'/foo/bar/baz/',
-				'/foo/bar/baz'
+				...isWindows ? [`${driveLetter}\\foo\\bar\\baz`] : ['/foo/bar/baz']
 			],
 			'dot for current directory': [
 				'.',

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -8,7 +8,6 @@ const sinon = require('sinon');
 const process = require('process');
 const fs = require('fs');
 const chaiAsPromised = require('chai-as-promised');
-const os = require('os');
 const { getDriveLetter, isWin } = require('./helpers/test-helper');
 
 chai.use(chaiAsPromised);
@@ -22,9 +21,9 @@ describe('Utilities', () => {
 	let mockOS,
 		cliUtils;
 
-	const isWindows = isWin()
-	
-	const driveLetter = isWindows ? getDriveLetter() : ''
+	const isWindows = isWin();
+
+	const driveLetter = isWindows ? getDriveLetter() : '';
 
 	beforeEach(() => {
 		mockery.enable({
@@ -51,11 +50,11 @@ describe('Utilities', () => {
 	describe('parsePath()', () => {
 
 		leche.withData({
- 			'bare tilde': [
+			'bare tilde':	[
 				'~',
 				...isWindows ? [`${driveLetter}\\home\\user`] : ['/home/user']
 			],
- 			'subdirectory of tilde': [
+			'subdirectory of tilde': [
 				'~/foo/bar',
 				...isWindows ? [`${driveLetter}\\home\\user\\foo\\bar`] : ['/home/user/foo/bar']
 			],


### PR DESCRIPTION
Most of the tests were failing because of different linebreaks and file path structure on Windows. 

I also changed default log implementation to include proper end of line for Windows.

`should correctly download contents when Box folder has many items` for folders test is randomly failing on Windows or Mac. We probably need to do something about this in future. For now job could be re-run as workaround