### PR TITLE
fix: Fix `event:poll` polling-interval

### DIFF
--- a/src/commands/events/poll.js
+++ b/src/commands/events/poll.js
@@ -20,7 +20,11 @@ class EventsPollCommand extends BoxCommand {
 			options.endDate = flags['end-date'];
 		}
 		if (flags['polling-interval']) {
-			options.fetchInterval = flags['polling-interval'] * 1000;
+			if (flags.enterprise) {
+				options.pollingInterval = flags['polling-interval'] * 1000;
+			} else {
+				options.fetchInterval = flags['polling-interval'] * 1000;
+			}
 		}
 
 		await this.output('Polling started...');

--- a/src/commands/events/poll.js
+++ b/src/commands/events/poll.js
@@ -21,7 +21,7 @@ class EventsPollCommand extends BoxCommand {
 		}
 		if (flags['polling-interval']) {
 			if (flags.enterprise) {
-				options.pollingInterval = flags['polling-interval'] * 1000;
+				options.pollingInterval = flags['polling-interval'];
 			} else {
 				options.fetchInterval = flags['polling-interval'] * 1000;
 			}

--- a/src/commands/events/poll.js
+++ b/src/commands/events/poll.js
@@ -20,7 +20,7 @@ class EventsPollCommand extends BoxCommand {
 			options.endDate = flags['end-date'];
 		}
 		if (flags['polling-interval']) {
-			options.pollingInterval = flags['polling-interval'];
+			options.fetchInterval = flags['polling-interval'] * 1000;
 		}
 
 		await this.output('Polling started...');
@@ -56,7 +56,10 @@ EventsPollCommand.flags = {
 		description: 'Return enterprise events that occured before this time. Use a timestamp or shorthand syntax 00t, like 05w for 5 weeks.',
 		parse: input => BoxCommand.normalizeDateString(input),
 	}),
-	'polling-interval': flags.string({ description: 'Number of seconds to wait before polling for new events. Default is 60 seconds.' })
+	'polling-interval': flags.string({
+		description: 'Number of seconds to wait before polling for new events. Default is 60 seconds.',
+		parse: input => parseInt(input, 10),
+	})
 };
 
 


### PR DESCRIPTION
Closes: #418 & SDK-2725

This bug relating to wrong field passed to Node SDK, and the timing unit in Node SDK is using milliseconds but not seconds.