### PR TITLE
feat: Add support for folder update collaborators

### DIFF
--- a/src/commands/folders/update.js
+++ b/src/commands/folders/update.js
@@ -11,6 +11,12 @@ class FoldersUpdateCommand extends BoxCommand {
 		if (flags.name) {
 			updates.name = flags.name;
 		}
+		if (flags.hasOwnProperty('can-non-owners-invite') ) {
+			updates.can_non_owners_invite = flags['can-non-owners-invite'];
+		}
+		if (flags.hasOwnProperty('can-non-owners-view-collaborators')) {
+			updates.can_non_owners_view_collaborators = flags['can-non-owners-view-collaborators'];
+		}
 		if (flags.hasOwnProperty('description')) {
 			updates.description = flags.description;
 		}
@@ -48,6 +54,14 @@ FoldersUpdateCommand._endpoint = 'put_folders_id';
 FoldersUpdateCommand.flags = {
 	...BoxCommand.flags,
 	name: flags.string({ description: 'New name for folder' }),
+	'can-non-owners-invite': flags.boolean({
+		description: 'Specifies if users who are not the owner of the folder can invite new collaborators to the folder.',
+		allowNo: true
+	}),
+	'can-non-owners-view-collaborators': flags.boolean({
+		description: 'Restricts collaborators who are not the owner of this folder from viewing other collaborations on this folder.',
+		allowNo: true,
+	}),
 	description: flags.string({ description: 'New description for folder' }),
 	'upload-email-access': flags.string({
 		description: 'Upload email access level',

--- a/test/commands/folders.test.js
+++ b/test/commands/folders.test.js
@@ -1300,6 +1300,22 @@ describe('Folders', () => {
 				'--no-restrict-to-enterprise',
 				{is_collaboration_restricted_to_enterprise: false}
 			],
+			'can non owners invite flag': [
+				'--can-non-owners-invite',
+				{can_non_owners_invite: true}
+			],
+			'no can non owners invite flag': [
+				'--no-can-non-owners-invite',
+				{can_non_owners_invite: false}
+			],
+			'can non owners view collaborations flag': [
+				'--can-non-owners-view-collaborators',
+				{can_non_owners_view_collaborators: true}
+			],
+			'no can non owners view collaborations flag': [
+				'--no-can-non-owners-view-collaborators',
+				{can_non_owners_view_collaborators: false}
+			],
 			'upload email access flag': [
 				'--upload-email-access=open',
 				{folder_upload_email: {access: 'open'}}


### PR DESCRIPTION
Closes: #435 

It's turn out that the new flag `can-non-owners-invite` / `no-can-non-owners-invite` will be duplicate with `restrict-collaboration` / `no-restrict-collaboration` but I'm keeping both of them.