### PR TITLE
fix: Fix unit tests

### DIFF
--- a/src/commands/files/download.js
+++ b/src/commands/files/download.js
@@ -42,8 +42,9 @@ class FilesDownloadCommand extends BoxCommand {
 		}
 
 		let stream = await this.client.files.getReadStream(args.id, options);
+		let output;
 		try {
-			let output = fs.createWriteStream(filePath);
+			output = fs.createWriteStream(filePath);
 			stream.pipe(output);
 		} catch (ex) {
 			throw new BoxCLIError(`Could not download to destination file ${filePath}`, ex);
@@ -69,7 +70,7 @@ class FilesDownloadCommand extends BoxCommand {
 		/* eslint-disable promise/avoid-new */
 		// We need to await the end of the stream to avoid a race condition here
 		await new Promise((resolve, reject) => {
-			stream.on('end', resolve);
+			output.on('close', resolve);
 			stream.on('error', reject);
 		});
 		clearInterval(intervalUpdate);

--- a/src/commands/files/versions/download.js
+++ b/src/commands/files/versions/download.js
@@ -40,8 +40,9 @@ class FilesVersionsDownloadCommand extends BoxCommand {
 		options.version = args.fileVersionID;
 
 		let stream = await this.client.files.getReadStream(args.fileID, options);
+		let output;
 		try {
-			let output = fs.createWriteStream(filePath);
+			output = fs.createWriteStream(filePath);
 			stream.pipe(output);
 		} catch (ex) {
 			throw new BoxCLIError(`Could not download to destination file ${filePath}`, ex);
@@ -52,7 +53,7 @@ class FilesVersionsDownloadCommand extends BoxCommand {
 		/* eslint-disable promise/avoid-new */
 		// We need to await the end of the stream to avoid a race condition here
 		await new Promise((resolve, reject) => {
-			stream.on('end', resolve);
+			output.on('close', resolve);
 			stream.on('error', reject);
 		});
 		this.info(`Downloaded file ${fileName}`);

--- a/src/commands/folders/download.js
+++ b/src/commands/folders/download.js
@@ -23,8 +23,9 @@ const utils = require('../../util');
  */
 function saveFileToDisk(folderPath, file, stream) {
 
+	let output;
 	try {
-		let output = fs.createWriteStream(path.join(folderPath, file.path));
+		output = fs.createWriteStream(path.join(folderPath, file.path));
 		stream.pipe(output);
 	} catch (ex) {
 		throw new BoxCLIError(`Error downloading file ${file.id} to ${file.path}`, ex);
@@ -33,7 +34,7 @@ function saveFileToDisk(folderPath, file, stream) {
 	/* eslint-disable promise/avoid-new */
 	// We need to await the end of the stream to avoid a race condition here
 	return new Promise((resolve, reject) => {
-		stream.on('end', resolve);
+		output.on('close', resolve);
 		stream.on('error', reject);
 	});
 	/* eslint-enable promise/avoid-new */
@@ -184,7 +185,6 @@ class FoldersDownloadCommand extends BoxCommand {
 		/* eslint-disable promise/avoid-new */
 		// We need to await the end of the stream to avoid a race condition here
 		return new Promise((resolve, reject) => {
-			output.on('end', resolve);
 			output.on('close', resolve);
 			output.on('error', reject);
 		});

--- a/test/commands/files.test.js
+++ b/test/commands/files.test.js
@@ -2349,7 +2349,7 @@ describe('Files', () => {
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
 				.get(downloadUrl)
-				.reply(200, function () {
+				.reply(200, function() {
 					return fs.createReadStream(testFilePath, 'utf8');
 				})
 			)
@@ -2357,9 +2357,9 @@ describe('Files', () => {
 				.get(statusUrl)
 				.reply(200, downloadStatusFixture)
 			)
-			.do(() => {
+			.do(async() => {
 				/* eslint-disable no-sync */
-				fs.writeFileSync(path.join(DEFAULT_DOWNLOAD_PATH, fileName), 'foo', 'utf8');
+				await fs.writeFileSync(path.join(DEFAULT_DOWNLOAD_PATH, fileName), 'foo');
 				/* eslint-enable no-sync */
 			})
 			.stdout()

--- a/test/commands/folders.test.js
+++ b/test/commands/folders.test.js
@@ -1486,20 +1486,20 @@ describe('Folders', () => {
 			}
 		};
 
-		async function getDirectoryContents(folderPath) {
-
+		function getDirectoryContents(folderPath) {
+			/* eslint-disable no-sync */
 			let obj = {};
-			let folderContents = await fs.readdir(folderPath);
-			folderContents.forEach(async item => {
+			let folderContents = fs.readdirSync(folderPath);
+			folderContents.forEach(item => {
 				let itemPath = path.join(folderPath, item);
-				let stat = await fs.stat(itemPath);
+				let stat = fs.statSync(itemPath);
 				if (stat.isDirectory()) {
-					obj[item] = await getDirectoryContents(itemPath);
+					obj[item] = getDirectoryContents(itemPath);
 				} else {
-					obj[item] = await fs.readFile(itemPath, 'utf8');
+					obj[item] = fs.readFileSync(itemPath, 'utf8');
 				}
 			});
-
+			/* eslint-enable no-sync */
 			return obj;
 		}
 
@@ -1534,7 +1534,7 @@ describe('Folders', () => {
 			])
 			.it('should download folder to specified path on disk when called with destination flag', async ctx => {
 				let folderPath = path.join(downloadPath, folderName);
-				let actualContents = await getDirectoryContents(folderPath);
+				let actualContents = getDirectoryContents(folderPath);
 				await fs.remove(downloadPath);
 
 				assert.deepEqual(actualContents, expectedContents);
@@ -1588,7 +1588,7 @@ describe('Folders', () => {
 					manyFilesExpectedContents[`file ${i}.txt`] = `File ${i} contents`;
 				}
 				let folderPath = path.join(downloadPath, folderName);
-				let actualContents = await getDirectoryContents(folderPath);
+				let actualContents = getDirectoryContents(folderPath);
 				await fs.remove(downloadPath);
 
 				assert.deepEqual(actualContents, manyFilesExpectedContents);
@@ -1621,7 +1621,7 @@ describe('Folders', () => {
 			])
 			.it('should only download files in top-level folder when --depth=0 flag is passed', async ctx => {
 				let folderPath = path.join(downloadPath, folderName);
-				let actualContents = await getDirectoryContents(folderPath);
+				let actualContents = getDirectoryContents(folderPath);
 				await fs.remove(downloadPath);
 
 				assert.deepEqual(actualContents, _.omit(expectedContents, 'subfolder'));
@@ -1725,7 +1725,7 @@ describe('Folders', () => {
 			])
 			.it('should download a folder a non-existent path', async(ctx) => {
 				let folderPath = path.join(destination, folderName);
-				let actualContents = await getDirectoryContents(folderPath);
+				let actualContents = getDirectoryContents(folderPath);
 				await fs.remove(destination);
 
 				assert.deepEqual(actualContents, expectedContents);
@@ -1762,7 +1762,7 @@ describe('Folders', () => {
 			])
 			.it('should download a folder to a default destination', async(ctx) => {
 				let folderPath = path.join(DEFAULT_DOWNLOAD_PATH, folderName);
-				let actualContents = await getDirectoryContents(folderPath);
+				let actualContents = getDirectoryContents(folderPath);
 				await fs.remove(folderPath);
 
 				assert.deepEqual(actualContents, expectedContents);


### PR DESCRIPTION
Instead of listening for writing stream `end` from the API request, we should wait for `close` event of the file stream to make sure that the file writing is finished.