### PR TITLE
feat: add `max-items`, improve list endpoints performance

### DIFF
--- a/src/box-command.js
+++ b/src/box-command.js
@@ -959,8 +959,13 @@ class BoxCommand extends Command {
 		if (typeof obj.next === 'function') {
 			output = [];
 				let entry = await obj.next();
-				while (!entry.done && !this.maxItemsReached(this.flags['max-items'], output.length)) {
+				while (!entry.done) {
 					output.push(entry.value);
+
+					if (this.maxItemsReached(this.flags['max-items'], output.length)) {
+						break;
+					}
+
 					/* eslint-disable no-await-in-loop */
 					entry = await obj.next();
 					/* eslint-enable no-await-in-loop */

--- a/src/commands/collaboration-allowlist/exemptions/index.js
+++ b/src/commands/collaboration-allowlist/exemptions/index.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const BoxCommand = require('../../../box-command');
+const PaginationUtils = require('../../../pagination-utils');
 
 class CollaborationAllowlistListExemptUserCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(CollaborationAllowlistListExemptUserCommand);
-		let options = {};
+		let options = PaginationUtils.handlePagination(flags);
 
 		if (flags.fields) {
 			options.fields = flags.fields;
@@ -21,7 +22,8 @@ CollaborationAllowlistListExemptUserCommand.examples = ['box collaboration-allow
 CollaborationAllowlistListExemptUserCommand._endpoint = 'get_collaboration_whitelist_exempt_targets';
 
 CollaborationAllowlistListExemptUserCommand.flags = {
-	...BoxCommand.flags
+	...BoxCommand.flags,
+	...PaginationUtils.flags,
 };
 
 module.exports = CollaborationAllowlistListExemptUserCommand;

--- a/src/commands/collaboration-allowlist/index.js
+++ b/src/commands/collaboration-allowlist/index.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const BoxCommand = require('../../box-command');
+const PaginationUtils = require('../../pagination-utils');
 
 class CollaborationAllowlistListCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(CollaborationAllowlistListCommand);
-		let options = {};
+		let options = PaginationUtils.handlePagination(flags);
 
 		if (flags.fields) {
 			options.fields = flags.fields;
@@ -21,7 +22,8 @@ CollaborationAllowlistListCommand.examples = ['box collaboration-allowlist'];
 CollaborationAllowlistListCommand._endpoint = 'get_collaboration_whitelist_entries';
 
 CollaborationAllowlistListCommand.flags = {
-	...BoxCommand.flags
+	...BoxCommand.flags,
+	...PaginationUtils.flags,
 };
 
 module.exports = CollaborationAllowlistListCommand;

--- a/src/commands/collaborations/pending.js
+++ b/src/commands/collaborations/pending.js
@@ -2,13 +2,16 @@
 
 const BoxCommand = require('../../box-command');
 const { flags } = require('@oclif/command');
+const PaginationUtils = require('../../pagination-utils');
 
 class CollaborationsGetPendingCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(CollaborationsGetPendingCommand);
+		let options = PaginationUtils.handlePagination(flags);
 		let params = {
 			qs: {
-				status: 'pending'
+				status: 'pending',
+				limit: options.limit
 			}
 		};
 
@@ -30,6 +33,7 @@ CollaborationsGetPendingCommand._endpoint = 'get_collaborations pending';
 
 CollaborationsGetPendingCommand.flags = {
 	...BoxCommand.flags,
+	...PaginationUtils.flags,
 };
 
 module.exports = CollaborationsGetPendingCommand;

--- a/src/commands/collections/items.js
+++ b/src/commands/collections/items.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const BoxCommand = require('../../box-command');
+const PaginationUtils = require('../../pagination-utils');
 
 class CollectionsListItemsCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(CollectionsListItemsCommand);
-		let options = {};
+		let options = PaginationUtils.handlePagination(flags);
 
 		if (flags.fields) {
 			options.fields = flags.fields;
@@ -21,7 +22,8 @@ CollectionsListItemsCommand.examples = ['box collections:items 12345'];
 CollectionsListItemsCommand._endpoint = 'get_collections_id_items';
 
 CollectionsListItemsCommand.flags = {
-	...BoxCommand.flags
+	...BoxCommand.flags,
+	...PaginationUtils.flags,
 };
 
 CollectionsListItemsCommand.args = [

--- a/src/commands/device-pins/index.js
+++ b/src/commands/device-pins/index.js
@@ -2,11 +2,12 @@
 
 const BoxCommand = require('../../box-command');
 const { flags } = require('@oclif/command');
+const PaginationUtils = require('../../pagination-utils');
 
 class DevicePinsListCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(DevicePinsListCommand);
-		let options = {};
+		let options = PaginationUtils.handlePagination(flags);
 
 		if (flags.direction) {
 			options.direction = flags.direction;
@@ -23,6 +24,7 @@ DevicePinsListCommand._endpoint = 'get_enterprises_id_device_pinners';
 
 DevicePinsListCommand.flags = {
 	...BoxCommand.flags,
+	...PaginationUtils.flags,
 	direction: flags.string({
 		description: 'Set sorting (by id) direction. Default is ASC',
 		options: [

--- a/src/commands/files/collaborations/index.js
+++ b/src/commands/files/collaborations/index.js
@@ -2,11 +2,12 @@
 
 const BoxCommand = require('../../../box-command');
 const { flags } = require('@oclif/command');
+const PaginationUtils = require('../../../pagination-utils');
 
 class FilesCollaborationsListCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(FilesCollaborationsListCommand);
-		let options = {};
+		let options = PaginationUtils.handlePagination(flags);
 
 		if (flags.fields) {
 			options.fields = flags.fields;
@@ -25,6 +26,7 @@ FilesCollaborationsListCommand._endpoint = 'get_files_id_collaborations';
 
 FilesCollaborationsListCommand.flags = {
 	...BoxCommand.flags,
+	...PaginationUtils.flags,
 };
 
 FilesCollaborationsListCommand.args = [

--- a/src/commands/files/comments.js
+++ b/src/commands/files/comments.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const BoxCommand = require('../../box-command');
+const PaginationUtils = require('../../pagination-utils');
 
 class CommentsListCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(CommentsListCommand);
-		let options = {};
+		let options = PaginationUtils.handlePagination(flags);
 
 		if (flags.fields) {
 			options.fields = flags.fields;
@@ -23,7 +24,8 @@ CommentsListCommand.examples = ['box files:comments 11111'];
 CommentsListCommand._endpoint = 'get_files_id_comments';
 
 CommentsListCommand.flags = {
-	...BoxCommand.flags
+	...BoxCommand.flags,
+	...PaginationUtils.pagingFlag,
 };
 
 CommentsListCommand.args = [

--- a/src/commands/files/versions/index.js
+++ b/src/commands/files/versions/index.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const BoxCommand = require('../../../box-command');
+const PaginationUtils = require('../../../pagination-utils');
 
 class FilesListVersionsCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(FilesListVersionsCommand);
-		let options = {};
+		let options = PaginationUtils.handlePagination(flags);
 
 		if (flags.fields) {
 			options.fields = flags.fields;
@@ -23,7 +24,8 @@ FilesListVersionsCommand.examples = ['box files:versions 11111'];
 FilesListVersionsCommand._endpoint = 'get_files_id_versions';
 
 FilesListVersionsCommand.flags = {
-	...BoxCommand.flags
+	...BoxCommand.flags,
+	...PaginationUtils.flags,
 };
 
 FilesListVersionsCommand.args = [

--- a/src/commands/folders/items.js
+++ b/src/commands/folders/items.js
@@ -2,13 +2,12 @@
 
 const BoxCommand = require('../../box-command');
 const { flags } = require('@oclif/command');
+const PaginationUtils = require('../../pagination-utils');
 
 class FoldersListItemsCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(FoldersListItemsCommand);
-		let options = {
-			usemarker: true,
-		};
+		let options = PaginationUtils.forceMarkerPagination(flags);
 
 		if (flags.fields) {
 			options.fields = flags.fields;
@@ -34,6 +33,7 @@ FoldersListItemsCommand._endpoint = 'get_folders_id_items';
 
 FoldersListItemsCommand.flags = {
 	...BoxCommand.flags,
+	...PaginationUtils.flags,
 	direction: flags.string({
 		description: 'The direction to order returned items',
 		options: [

--- a/src/commands/groups/collaborations.js
+++ b/src/commands/groups/collaborations.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const BoxCommand = require('../../box-command');
+const PaginationUtils = require('../../pagination-utils');
 
 class GroupsListCollaborationsCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(GroupsListCollaborationsCommand);
-		let options = {};
+		let options = PaginationUtils.handlePagination(flags);
 
 		if (flags.fields) {
 			options.fields = flags.fields;
@@ -26,7 +27,8 @@ GroupsListCollaborationsCommand.examples = ['box groups:collaborations 12345'];
 GroupsListCollaborationsCommand._endpoint = 'get_groups_id_collaborations';
 
 GroupsListCollaborationsCommand.flags = {
-	...BoxCommand.flags
+	...BoxCommand.flags,
+	...PaginationUtils.flag,
 };
 
 GroupsListCollaborationsCommand.args = [

--- a/src/commands/groups/index.js
+++ b/src/commands/groups/index.js
@@ -2,11 +2,12 @@
 
 const BoxCommand = require('../../box-command');
 const { flags } = require('@oclif/command');
+const PaginationUtils = require('../../pagination-utils');
 
 class GroupsListCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(GroupsListCommand);
-		let options = {};
+		let options = PaginationUtils.handlePagination(flags);
 
 		if (flags.fields) {
 			options.fields = flags.fields;
@@ -29,6 +30,7 @@ GroupsListCommand._endpoint = 'get_groups';
 
 GroupsListCommand.flags = {
 	...BoxCommand.flags,
+	...PaginationUtils.flags,
 	filter: flags.string({
 		description: 'Search term to filter groups on; matches prefixes of group name',
 	})

--- a/src/commands/groups/memberships/index.js
+++ b/src/commands/groups/memberships/index.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const BoxCommand = require('../../../box-command');
+const PaginationUtils = require('../../../pagination-utils');
 
 class GroupsListMembershipCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(GroupsListMembershipCommand);
-		let options = {};
+		let options = PaginationUtils.handlePagination(flags);
 
 		if (flags.fields) {
 			options.fields = flags.fields;
@@ -23,7 +24,8 @@ GroupsListMembershipCommand.examples = ['box groups:memberships 12345'];
 GroupsListMembershipCommand._endpoint = 'get_groups_id_memberships';
 
 GroupsListMembershipCommand.flags = {
-	...BoxCommand.flags
+	...BoxCommand.flags,
+	...PaginationUtils.flags,
 };
 
 GroupsListMembershipCommand.args = [

--- a/src/commands/legal-hold-policies/assignments/index.js
+++ b/src/commands/legal-hold-policies/assignments/index.js
@@ -2,11 +2,12 @@
 
 const BoxCommand = require('../../../box-command');
 const { flags } = require('@oclif/command');
+const PaginationUtils = require('../../../pagination-utils');
 
 class LegalHoldPoliciesListAssignmentsCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(LegalHoldPoliciesListAssignmentsCommand);
-		let options = {};
+		let options = PaginationUtils.handlePagination(flags);
 
 		if (flags['assign-to-type']) {
 			options.assign_to_type = flags['assign-to-type'];
@@ -30,6 +31,7 @@ LegalHoldPoliciesListAssignmentsCommand._endpoint = 'get_legal_hold_policy_assig
 
 LegalHoldPoliciesListAssignmentsCommand.flags = {
 	...BoxCommand.flags,
+	...PaginationUtils.flags,
 	'assign-to-type': flags.string({
 		description: 'Filter by assignment type',
 		options: [

--- a/src/commands/legal-hold-policies/file-version-holds/index.js
+++ b/src/commands/legal-hold-policies/file-version-holds/index.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const BoxCommand = require('../../../box-command');
+const PaginationUtils = require('../../../pagination-utils');
 
 class LegalHoldPoliciesListVersionHoldsCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(LegalHoldPoliciesListVersionHoldsCommand);
-		let options = {};
+		let options = PaginationUtils.handlePagination(flags);
 
 		if (flags.fields) {
 			options.fields = flags.fields;
@@ -21,7 +22,8 @@ LegalHoldPoliciesListVersionHoldsCommand.examples = ['box legal-hold-policies:fi
 LegalHoldPoliciesListVersionHoldsCommand._endpoint = 'get_file_version_legal_holds';
 
 LegalHoldPoliciesListVersionHoldsCommand.flags = {
-	...BoxCommand.flags
+	...BoxCommand.flags,
+	...PaginationUtils.flags,
 };
 
 LegalHoldPoliciesListVersionHoldsCommand.args = [

--- a/src/commands/legal-hold-policies/index.js
+++ b/src/commands/legal-hold-policies/index.js
@@ -2,11 +2,12 @@
 
 const BoxCommand = require('../../box-command');
 const { flags } = require('@oclif/command');
+const PaginationUtils = require('../../pagination-utils');
 
 class LegalHoldPoliciesListCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(LegalHoldPoliciesListCommand);
-		let options = {};
+		let options = PaginationUtils.handlePagination(flags);
 
 		if (flags['policy-name']) {
 			options.policy_name = flags['policy-name'];
@@ -27,6 +28,7 @@ LegalHoldPoliciesListCommand._endpoint = 'get_legal_hold_policies';
 
 LegalHoldPoliciesListCommand.flags = {
 	...BoxCommand.flags,
+	...PaginationUtils.flags,
 	'policy-name': flags.string({ description: 'Filter by policy name' })
 };
 

--- a/src/commands/metadata-cascade-policies/index.js
+++ b/src/commands/metadata-cascade-policies/index.js
@@ -2,11 +2,12 @@
 
 const BoxCommand = require('../../box-command');
 const { flags } = require('@oclif/command');
+const PaginationUtils = require('../../pagination-utils');
 
 class MetadataCascadePoliciesListCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(MetadataCascadePoliciesListCommand);
-		let options = {};
+		let options = PaginationUtils.handlePagination(flags);
 
 		if (flags['owner-enterprise-id']) {
 			options.owner_enterprise_id = flags['owner-enterprise-id'];
@@ -23,6 +24,7 @@ MetadataCascadePoliciesListCommand._endpoint = 'get_metadata_cascade_policies';
 
 MetadataCascadePoliciesListCommand.flags = {
 	...BoxCommand.flags,
+	...PaginationUtils.flags,
 	'owner-enterprise-id': flags.string({ description: 'The ID of the enterprise to filter cascade policies for '}),
 };
 

--- a/src/commands/metadata-templates/cascade.js
+++ b/src/commands/metadata-templates/cascade.js
@@ -15,7 +15,7 @@ class MetadataCascadePoliciesCreateCommand extends BoxCommand {
 MetadataCascadePoliciesCreateCommand.description = 'Create a new metadata cascade policy on a folder';
 MetadataCascadePoliciesCreateCommand.examples = ['box metadata-templates:cascade employeeRecord --folder 22222'];
 MetadataCascadePoliciesCreateCommand._endpoint = 'post_metadata_cascade_policies';
-MetadataCascadePoliciesCreateCommand.aliases = ['metadata-cascade-policies:create']
+MetadataCascadePoliciesCreateCommand.aliases = ['metadata-cascade-policies:create'];
 
 MetadataCascadePoliciesCreateCommand.flags = {
 	...BoxCommand.flags,

--- a/src/commands/recent-items.js
+++ b/src/commands/recent-items.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const BoxCommand = require('../box-command');
+const PaginationUtils = require('../pagination-utils');
 
 class RecentItems extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(RecentItems);
-		let options = {};
+		let options = PaginationUtils.handlePagination(flags);
 
 		if (flags.fields) {
 			options.fields = flags.fields;
@@ -21,7 +22,8 @@ RecentItems.examples = ['box recent-items'];
 RecentItems._endpoint = 'get_recent_items';
 
 RecentItems.flags = {
-	...BoxCommand.flags
+	...BoxCommand.flags,
+	...PaginationUtils.flags,
 };
 
 module.exports = RecentItems;

--- a/src/commands/retention-policies/assignments/index.js
+++ b/src/commands/retention-policies/assignments/index.js
@@ -8,7 +8,6 @@ class RetentionPoliciesListCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(RetentionPoliciesListCommand);
 		let options = PaginationUtils.handlePagination(flags);
-		// let options = {};
 
 		if (flags.type) {
 			options.type = flags.type;

--- a/src/commands/retention-policies/assignments/index.js
+++ b/src/commands/retention-policies/assignments/index.js
@@ -2,11 +2,13 @@
 
 const BoxCommand = require('../../../box-command');
 const { flags } = require('@oclif/command');
+const PaginationUtils = require('../../../pagination-utils');
 
 class RetentionPoliciesListCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(RetentionPoliciesListCommand);
-		let options = {};
+		let options = PaginationUtils.handlePagination(flags);
+		// let options = {};
 
 		if (flags.type) {
 			options.type = flags.type;
@@ -27,6 +29,7 @@ RetentionPoliciesListCommand._endpoint = 'get_retention_policies_id_assignments'
 
 RetentionPoliciesListCommand.flags = {
 	...BoxCommand.flags,
+	...PaginationUtils.flags,
 	type: flags.string({
 		description: 'The type of the retention policy assignment to retrieve',
 		options: [

--- a/src/commands/retention-policies/file-version-retentions/index.js
+++ b/src/commands/retention-policies/file-version-retentions/index.js
@@ -2,11 +2,12 @@
 
 const BoxCommand = require('../../../box-command');
 const { flags } = require('@oclif/command');
+const PaginationUtils = require('../../../pagination-utils');
 
 class RetentionPoliciesListVersionRetentionCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(RetentionPoliciesListVersionRetentionCommand);
-		let options = {};
+		let options = PaginationUtils.handlePagination(flags);
 
 		if (flags['disposition-action']) {
 			options.disposition_action = flags['disposition-action'];
@@ -42,6 +43,7 @@ RetentionPoliciesListVersionRetentionCommand._endpoint = 'get_file_version_reten
 
 RetentionPoliciesListVersionRetentionCommand.flags = {
 	...BoxCommand.flags,
+	...PaginationUtils.flags,
 	'disposition-action': flags.string({
 		description: 'A disposition action to filter by',
 		options: [

--- a/src/commands/retention-policies/file-versions-under-retention/get.js
+++ b/src/commands/retention-policies/file-versions-under-retention/get.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const BoxCommand = require('../../../box-command');
+const PaginationUtils = require('../../../pagination-utils');
 
 class RetentionPoliciesGetFileVersionsRetentionForAssignmentCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(RetentionPoliciesGetFileVersionsRetentionForAssignmentCommand);
-		let options = {};
+		let options = PaginationUtils.handlePagination(flags);
 
 		if (flags.fields) {
 			options.fields = flags.fields;
@@ -20,7 +21,8 @@ RetentionPoliciesGetFileVersionsRetentionForAssignmentCommand.description = 'Get
 RetentionPoliciesGetFileVersionsRetentionForAssignmentCommand.examples = ['box retention-policies:file-versions-under-retention:get 77777'];
 RetentionPoliciesGetFileVersionsRetentionForAssignmentCommand._endpoint = 'get_retention_policy_assignments_id_file_versions_under_retention';
 RetentionPoliciesGetFileVersionsRetentionForAssignmentCommand.flags = {
-	...BoxCommand.flags
+	...BoxCommand.flags,
+	...PaginationUtils.flags,
 };
 
 RetentionPoliciesGetFileVersionsRetentionForAssignmentCommand.args = [

--- a/src/commands/retention-policies/files-under-retention/get.js
+++ b/src/commands/retention-policies/files-under-retention/get.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const BoxCommand = require('../../../box-command');
+const PaginationUtils = require('../../../pagination-utils');
 
 class RetentionPoliciesGetFilesRetentionForAssignmentCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(RetentionPoliciesGetFilesRetentionForAssignmentCommand);
-		let options = {};
+		let options = PaginationUtils.handlePagination(flags);
 
 		if (flags.fields) {
 			options.fields = flags.fields;
@@ -21,7 +22,8 @@ RetentionPoliciesGetFilesRetentionForAssignmentCommand.examples = ['box retentio
 RetentionPoliciesGetFilesRetentionForAssignmentCommand._endpoint = 'get_retention_policy_assignments_id_files_under_retention';
 
 RetentionPoliciesGetFilesRetentionForAssignmentCommand.flags = {
-	...BoxCommand.flags
+	...BoxCommand.flags,
+	...PaginationUtils.flags,
 };
 
 RetentionPoliciesGetFilesRetentionForAssignmentCommand.args = [

--- a/src/commands/retention-policies/index.js
+++ b/src/commands/retention-policies/index.js
@@ -2,11 +2,12 @@
 
 const BoxCommand = require('../../box-command');
 const { flags } = require('@oclif/command');
+const PaginationUtils = require('../../pagination-utils');
 
 class RetentionPoliciesListCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(RetentionPoliciesListCommand);
-		let options = {};
+		let options = PaginationUtils.handlePagination(flags);
 
 		if (flags['policy-name']) {
 			options.policy_name = flags['policy-name'];
@@ -33,6 +34,7 @@ RetentionPoliciesListCommand._endpoint = 'get_retention_policies';
 
 RetentionPoliciesListCommand.flags = {
 	...BoxCommand.flags,
+	...PaginationUtils.flags,
 	'policy-name': flags.string({
 		char: 'n',
 		description: 'A name to filter the retention policies by'

--- a/src/commands/storage-policies/index.js
+++ b/src/commands/storage-policies/index.js
@@ -1,12 +1,14 @@
 'use strict';
 
 const BoxCommand = require('../../box-command');
+const PaginationUtils = require('../../pagination-utils');
 
 class StoragePoliciesListCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(StoragePoliciesListCommand);
+		let options = PaginationUtils.handlePagination(flags);
 
-		let storagePolicies = await this.client.storagePolicies.getAll();
+		let storagePolicies = await this.client.storagePolicies.getAll(options);
 		await this.output(storagePolicies);
 	}
 }
@@ -18,7 +20,8 @@ StoragePoliciesListCommand.examples = ['box storage-policies'];
 StoragePoliciesListCommand._endpoint = 'get_storage_policies';
 
 StoragePoliciesListCommand.flags = {
-	...BoxCommand.flags
+	...BoxCommand.flags,
+	...PaginationUtils.flags,
 };
 
 module.exports = StoragePoliciesListCommand;

--- a/src/commands/trash/index.js
+++ b/src/commands/trash/index.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const BoxCommand = require('../../box-command');
+const PaginationUtils = require('../../pagination-utils');
 
 class TrashListCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(TrashListCommand);
-		let options = {};
+		let options = PaginationUtils.forceMarkerPagination(flags);
 
 		if (flags.fields) {
 			options.fields = flags.fields;
@@ -23,7 +24,8 @@ TrashListCommand.examples = ['box trash'];
 TrashListCommand._endpoint = 'get_folders_trash_items';
 
 TrashListCommand.flags = {
-	...BoxCommand.flags
+	...BoxCommand.flags,
+	...PaginationUtils.flags,
 };
 
 module.exports = TrashListCommand;

--- a/src/commands/users/groups.js
+++ b/src/commands/users/groups.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const BoxCommand = require('../../box-command');
+const PaginationUtils = require('../../pagination-utils');
 
 class UsersListGroupsCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(UsersListGroupsCommand);
-		let options = {};
+		let options = PaginationUtils.handlePagination(flags);
 
 		if (flags.fields) {
 			options.fields = flags.fields;
@@ -23,7 +24,8 @@ UsersListGroupsCommand.examples = ['box users:groups 33333'];
 UsersListGroupsCommand._endpoint = 'get_users_id_memberships';
 
 UsersListGroupsCommand.flags = {
-	...BoxCommand.flags
+	...BoxCommand.flags,
+	...PaginationUtils.flags,
 };
 
 UsersListGroupsCommand.args = [

--- a/src/commands/users/index.js
+++ b/src/commands/users/index.js
@@ -3,10 +3,14 @@
 const BoxCommand = require('../../box-command');
 const { flags } = require('@oclif/command');
 const UserModule = require('../../modules/user');
+const PaginationUtils = require('../../pagination-utils');
 
 class UsersListCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(UsersListCommand);
+		let options = PaginationUtils.forceMarkerPagination(flags);
+		flags.limit = options.limit;
+		flags.usemarker = options.usemarker;
 
 		let userModule = new UserModule(this.client);
 		let users = await userModule.listUsers(flags);
@@ -22,6 +26,7 @@ UsersListCommand._endpoint = 'get_users';
 
 UsersListCommand.flags = {
 	...BoxCommand.flags,
+	...PaginationUtils.flags,
 	'managed-users': flags.boolean({
 		char: 'm',
 		description: 'Limit results to managed users only',

--- a/src/commands/webhooks/index.js
+++ b/src/commands/webhooks/index.js
@@ -1,12 +1,14 @@
 'use strict';
 
 const BoxCommand = require('../../box-command');
+const PaginationUtils = require('../../pagination-utils');
 
 class WebhooksListCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = this.parse(WebhooksListCommand);
+		let options = PaginationUtils.handlePagination(flags);
 
-		let webhooks = await this.client.webhooks.getAll();
+		let webhooks = await this.client.webhooks.getAll(options);
 		await this.output(webhooks);
 	}
 }
@@ -18,7 +20,8 @@ WebhooksListCommand.examples = ['box webhooks'];
 WebhooksListCommand._endpoint = 'get_webhooks';
 
 WebhooksListCommand.flags = {
-	...BoxCommand.flags
+	...BoxCommand.flags,
+	...PaginationUtils.flags,
 };
 
 module.exports = WebhooksListCommand;

--- a/src/modules/user.js
+++ b/src/modules/user.js
@@ -37,6 +37,14 @@ class UserModule {
 			options.user_type = 'external';
 		}
 
+		if (flags.limit) {
+			options.limit = flags.limit;
+		}
+
+		if (flags.usemarker) {
+			options.usemarker = flags.usemarker;
+		}
+
 		if (flags.filter) {
 			options.filter_term = flags.filter;
 		}

--- a/src/pagination-utils.js
+++ b/src/pagination-utils.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const { flags } = require('@oclif/command');
+
+const MAX_LIMIT = 1000;
+
+/**
+ * Sets correct limit option based on max-items flag.
+ * If max-items is not present limit is set to 1000
+ *
+ * @param {Object} commandFlags Flags from the command
+ * @returns {Object} Options for http request
+ * @private
+ *
+ **/
+function parsePaginationFlags(commandFlags) {
+	let limitFlag =
+		commandFlags['max-items'] === undefined
+			? MAX_LIMIT
+			: commandFlags['max-items'];
+
+	if (limitFlag <= 0) {
+		throw new Error('Max items must be greater than 0');
+	}
+
+	let options = { limit: Math.min(MAX_LIMIT, limitFlag) };
+
+	return options;
+}
+
+module.exports = {
+	forceMarkerPagination(commandFlags) {
+		let options = parsePaginationFlags(commandFlags);
+		options.usemarker = true;
+
+		return options;
+	},
+
+	handlePagination(commandFlags) {
+		return parsePaginationFlags(commandFlags);
+	},
+};
+
+module.exports.flags = Object.freeze({
+	'max-items': flags.integer({
+		description:
+			'A value that indicates the maximum number of results to return for a single request. This only specifies a maximum boundary and will not guarantee the minimum number of results returned.',
+	}),
+});

--- a/src/pagination-utils.js
+++ b/src/pagination-utils.js
@@ -44,6 +44,6 @@ module.exports = {
 module.exports.flags = Object.freeze({
 	'max-items': flags.integer({
 		description:
-			'A value that indicates the maximum number of results to return for a single request. This only specifies a maximum boundary and will not guarantee the minimum number of results returned.',
+			'A value that indicates the maximum number of results to return. This only specifies a maximum boundary and will not guarantee the minimum number of results returned. When the max-items (x) is greater than 1000, then the maximum ceil(x/1000) requests will be made.',
 	}),
 });

--- a/test/commands/bulk.test.js
+++ b/test/commands/bulk.test.js
@@ -1136,7 +1136,7 @@ describe('Bulk', () => {
 		test
 			.nock(TEST_API_ROOT, api => api
 				.get('/2.0/folders/0/items')
-				.query({ usemarker: true })
+				.query({ usemarker: true, limit: 1000 })
 				.reply(200, fixture3)
 			)
 			.stdout()

--- a/test/commands/collaboration-allowlist.test.js
+++ b/test/commands/collaboration-allowlist.test.js
@@ -131,10 +131,12 @@ describe('Collaboration-Allowlist', () => {
 		test
 			.nock(TEST_API_ROOT, api => api
 				.get('/2.0/collaboration_whitelist_entries')
+				.query({limit: 1000})
 				.reply(200, fixture)
 				.get('/2.0/collaboration_whitelist_entries')
 				.query({
-					marker: 'ZEDFO9'
+					marker: 'ZEDFO9',
+					limit: 1000
 				})
 				.reply(200, fixture2)
 			)
@@ -151,12 +153,13 @@ describe('Collaboration-Allowlist', () => {
 		test
 			.nock(TEST_API_ROOT, api => api
 				.get('/2.0/collaboration_whitelist_entries')
-				.query({fields: 'direction'})
+				.query({fields: 'direction', limit: 1000})
 				.reply(200, fixture)
 				.get('/2.0/collaboration_whitelist_entries')
 				.query({
 					fields: 'direction',
-					marker: 'ZEDFO9'
+					marker: 'ZEDFO9',
+					limit: 1000
 				})
 				.reply(200, fixture2)
 			)
@@ -274,10 +277,12 @@ describe('Collaboration-Allowlist', () => {
 		test
 			.nock(TEST_API_ROOT, api => api
 				.get('/2.0/collaboration_whitelist_exempt_targets')
+				.query({limit: 1000})
 				.reply(200, fixture)
 				.get('/2.0/collaboration_whitelist_exempt_targets')
 				.query({
-					marker: 'ZDEH786'
+					marker: 'ZDEH786',
+					limit: 1000
 				})
 				.reply(200, fixture2)
 			)
@@ -294,12 +299,13 @@ describe('Collaboration-Allowlist', () => {
 		test
 			.nock(TEST_API_ROOT, api => api
 				.get('/2.0/collaboration_whitelist_exempt_targets')
-				.query({fields: 'id'})
+				.query({fields: 'id', limit: 1000})
 				.reply(200, fixture)
 				.get('/2.0/collaboration_whitelist_exempt_targets')
 				.query({
 					fields: 'id',
-					marker: 'ZDEH786'
+					marker: 'ZDEH786',
+					limit: 1000
 				})
 				.reply(200, fixture2)
 			)

--- a/test/commands/collaborations.test.js
+++ b/test/commands/collaborations.test.js
@@ -593,13 +593,15 @@ describe('Collaborations', () => {
 				.nock(TEST_API_ROOT, api => api
 					.get('/2.0/collaborations')
 					.query({
-						status: 'pending'
+						status: 'pending',
+						limit: 1000
 					})
 					.reply(200, fixture)
 					.get('/2.0/collaborations')
 					.query({
 						status: 'pending',
-						offset: 1
+						offset: 1,
+						limit: 1000
 					})
 					.reply(200, fixture2)
 				)

--- a/test/commands/collections.test.js
+++ b/test/commands/collections.test.js
@@ -52,10 +52,12 @@ describe('Collections', () => {
 		test
 			.nock(TEST_API_ROOT, api => api
 				.get(`/2.0/collections/${collectionId}/items`)
+				.query({limit: 1000})
 				.reply(200, fixture)
 				.get(`/2.0/collections/${collectionId}/items`)
 				.query({
-					offset: 2
+					offset: 2,
+					limit: 1000
 				})
 				.reply(200, fixture2)
 			)
@@ -73,12 +75,13 @@ describe('Collections', () => {
 		test
 			.nock(TEST_API_ROOT, api => api
 				.get(`/2.0/collections/${collectionId}/items`)
-				.query({fields: 'name'})
+				.query({fields: 'name', limit: 1000})
 				.reply(200, fixture)
 				.get(`/2.0/collections/${collectionId}/items`)
 				.query({
 					fields: 'name',
-					offset: 2
+					offset: 2,
+					limit: 1000
 				})
 				.reply(200, fixture2)
 			)

--- a/test/commands/device-pins.test.js
+++ b/test/commands/device-pins.test.js
@@ -79,12 +79,13 @@ describe('Device Pins', () => {
 				})
 				.reply(200, userMeFixture)
 				.get(`/2.0/enterprises/${enterpriseId}/device_pinners`)
-				.query({ direction })
+				.query({ direction, limit: 1000 })
 				.reply(200, fixture)
 				.get(`/2.0/enterprises/${enterpriseId}/device_pinners`)
 				.query({
 					direction,
-					marker: 'ZDEF67'
+					marker: 'ZDEF67',
+					limit: 1000
 				})
 				.reply(200, fixture2)
 			)

--- a/test/commands/files.test.js
+++ b/test/commands/files.test.js
@@ -342,7 +342,7 @@ describe('Files', () => {
 	leche.withData([
 		'files:lock',
 		'files:update-lock',
-	], function (command) {
+	], function(command) {
 		describe(command, () => {
 			let fileId = '1234567890',
 				expireTime = '2030-01-01T08:00:00+00:00',
@@ -429,7 +429,7 @@ describe('Files', () => {
 	leche.withData([
 		'files:comments',
 		'comments:list'
-	], function (command) {
+		], function(command) {
 		describe(command, () => {
 			let fileId = '1234567890',
 				fixture = getFixture('comments/get_files_id_comments_page_1'),
@@ -438,10 +438,12 @@ describe('Files', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get(`/2.0/files/${fileId}/comments`)
+					.query({limit: 1000})
 					.reply(200, fixture)
 					.get(`/2.0/files/${fileId}/comments`)
 					.query({
-						offset: 2
+						offset: 2,
+						limit: 1000
 					})
 					.reply(200, fixture2)
 				)
@@ -458,12 +460,13 @@ describe('Files', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get(`/2.0/files/${fileId}/comments`)
-					.query({fields: 'message'})
+					.query({fields: 'message', limit: 1000})
 					.reply(200, fixture)
 					.get(`/2.0/files/${fileId}/comments`)
 					.query({
 						fields: 'message',
-						offset: 2
+						offset: 2,
+						limit: 1000
 					})
 					.reply(200, fixture2)
 				)
@@ -481,7 +484,7 @@ describe('Files', () => {
 	leche.withData([
 		'files:collaborations',
 		'files:collaborations:list'
-	], function (command) {
+	], function(command) {
 		describe(command, () => {
 			let fileId = '1234567890',
 				fixture = getFixture('files/get_files_id_collaborations_page_1'),
@@ -490,10 +493,12 @@ describe('Files', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get(`/2.0/files/${fileId}/collaborations`)
+					.query({limit: 1000})
 					.reply(200, fixture)
 					.get(`/2.0/files/${fileId}/collaborations`)
 					.query({
-						marker: 'ZAED53D'
+						marker: 'ZAED53D',
+						limit: 1000
 					})
 					.reply(200, fixture2)
 				)
@@ -510,12 +515,13 @@ describe('Files', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get(`/2.0/files/${fileId}/collaborations`)
-					.query({fields: 'accessible_by'})
+					.query({fields: 'accessible_by', limit: 1000})
 					.reply(200, fixture)
 					.get(`/2.0/files/${fileId}/collaborations`)
 					.query({
 						fields: 'accessible_by',
-						marker: 'ZAED53D'
+						marker: 'ZAED53D',
+						limit: 1000
 					})
 					.reply(200, fixture2)
 				)
@@ -725,7 +731,7 @@ describe('Files', () => {
 	leche.withData([
 		'files:metadata',
 		'files:metadata:get-all'
-	], function (command) {
+	], function(command) {
 		describe(command, () => {
 			let fileId = '123456789',
 				getAllMetadataFixture = getFixture('files/get_files_id_metadata'),
@@ -750,7 +756,7 @@ describe('Files', () => {
 	leche.withData([
 		'files:metadata:remove',
 		'files:metadata:delete'
-	], function (command) {
+	], function(command) {
 		describe(command, () => {
 			let fileId = '1234567890',
 				metadataScope = 'enterprise',
@@ -877,7 +883,7 @@ describe('Files', () => {
 	leche.withData([
 		'files:metadata:add',
 		'files:metadata:create'
-	], function (command) {
+	], function(command) {
 		describe(command, () => {
 			let fileId = '1234567890',
 				metadataScope = 'enterprise',
@@ -1027,7 +1033,7 @@ describe('Files', () => {
 		'files:share',
 		'files:shared-links:create',
 		'files:shared-links:update'
-	], function (command) {
+	], function(command) {
 		describe(command, () => {
 			let fileId = '1234567890',
 				unsharedDate = '2030-11-18T19:44:17+00:00',
@@ -1125,7 +1131,7 @@ describe('Files', () => {
 	leche.withData([
 		'files:unshare',
 		'files:shared-links:delete'
-	], function (command) {
+	], function(command) {
 		describe(command, () => {
 			let fileId = '1234567809',
 				getFileFixture = getFixture('files/get_files_id');
@@ -1173,7 +1179,7 @@ describe('Files', () => {
 	leche.withData([
 		'files:tasks',
 		'files:tasks:list'
-	], function (command) {
+	], function(command) {
 		describe(command, () => {
 			let fileId = '1234567890',
 				fixture = getFixture('files/get_files_id_tasks_page_1'),
@@ -1225,7 +1231,7 @@ describe('Files', () => {
 	leche.withData([
 		'files:versions',
 		'files:versions:list'
-	], function (command) {
+	], function(command) {
 		describe(command, () => {
 			let fileId = '1234567890',
 				fixture = getFixture('files/get_files_id_versions_page_1'),
@@ -1234,10 +1240,12 @@ describe('Files', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get(`/2.0/files/${fileId}/versions`)
+					.query({limit: 1000})
 					.reply(200, fixture)
 					.get(`/2.0/files/${fileId}/versions`)
 					.query({
-						offset: 2
+						offset: 2,
+						limit: 1000
 					})
 					.reply(200, fixture2)
 				)
@@ -1254,12 +1262,13 @@ describe('Files', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get(`/2.0/files/${fileId}/versions`)
-					.query({fields: 'sha1'})
+					.query({fields: 'sha1', limit: 1000})
 					.reply(200, fixture)
 					.get(`/2.0/files/${fileId}/versions`)
 					.query({
 						fields: 'sha1',
-						offset: 2
+						offset: 2,
+						limit: 1000
 					})
 					.reply(200, fixture2)
 				)
@@ -1480,9 +1489,8 @@ describe('Files', () => {
 			yamlOutput = getFixture('output/files_versions_upload_yaml.txt');
 		test
 			.nock(TEST_UPLOAD_ROOT, api => api
-				.post(`/2.0/files/${fileId}/content`, function (body) {
-					try
-					{
+				.post(`/2.0/files/${fileId}/content`, function(body) {
+					try {
 						let lines = body.split(/\r?\n/u);
 						assert.match(lines[0], /^-+\d+$/u);
 						assert.equal(lines[1], 'Content-Disposition: form-data; name="attributes"');
@@ -1495,9 +1503,7 @@ describe('Files', () => {
 						assert.equal(lines[7], '');
 						assert.equal(lines[8], testFileContent);
 						assert.match(lines[9], /^-+\d+-+$/u);
-					}
-					catch (error)
-					{
+					} catch (error) {
 						return false;
 					}
 					return true;
@@ -1518,9 +1524,8 @@ describe('Files', () => {
 			});
 		test
 			.nock(TEST_UPLOAD_ROOT, api => api
-				.post(`/2.0/files/${fileId}/content`, function (body) {
-					try
-					{
+				.post(`/2.0/files/${fileId}/content`, function(body) {
+					try {
 						let lines = body.split(/\r?\n/u);
 						assert.match(lines[0], /^-+\d+$/u);
 						assert.equal(lines[1], 'Content-Disposition: form-data; name="attributes"');
@@ -1533,9 +1538,7 @@ describe('Files', () => {
 						assert.equal(lines[7], '');
 						assert.equal(lines[8], testFileContent);
 						assert.match(lines[9], /^-+\d+-+$/u);
-					}
-					catch (error)
-					{
+					} catch (error) {
 						return false;
 					}
 					return true;
@@ -1555,16 +1558,13 @@ describe('Files', () => {
 			});
 		test
 			.nock(TEST_UPLOAD_ROOT, api => api
-				.post(`/2.0/files/${fileId}/content`, function (body) {
-					try
-					{
+				.post(`/2.0/files/${fileId}/content`, function(body) {
+					try {
 						let lines = body.split(/\r?\n/u);
 						let attributes = JSON.parse(lines[3]);
 						assert.propertyVal(attributes, 'content_modified_at', contentModifiedAt);
 						assert.equal(lines[8], testFileContent);
-					}
-					catch (error)
-					{
+					} catch (error) {
 						return false;
 					}
 					return true;
@@ -1597,17 +1597,14 @@ describe('Files', () => {
 			yamlOutput = getFixture('output/files_upload_yaml.txt');
 		test
 			.nock(TEST_UPLOAD_ROOT, api => api
-				.post('/2.0/files/content', function (body) {
-					try
-					{
+				.post('/2.0/files/content', function(body) {
+					try {
 						let lines = body.split(/\r?\n/u);
 						let attributes = JSON.parse(lines[3]);
 						assert.propertyVal(attributes, 'name', testFileName);
 						assert.nestedPropertyVal(attributes, 'parent.id', parentFolderId);
 						assert.equal(lines[8], testFileContent);
-					}
-					catch (error)
-					{
+					} catch (error) {
 						return false;
 					}
 					return true;
@@ -1628,17 +1625,14 @@ describe('Files', () => {
 			});
 		test
 			.nock(TEST_UPLOAD_ROOT, api => api
-				.post('/2.0/files/content', function (body) {
-					try
-					{
+				.post('/2.0/files/content', function(body) {
+					try {
 						let lines = body.split(/\r?\n/u);
 						let attributes = JSON.parse(lines[3]);
 						assert.propertyVal(attributes, 'name', testFileName);
 						assert.nestedPropertyVal(attributes, 'parent.id', parentFolderId);
 						assert.equal(lines[8], testFileContent);
-					}
-					catch (error)
-					{
+					} catch (error) {
 						return false;
 					}
 					return true;
@@ -1657,17 +1651,14 @@ describe('Files', () => {
 			});
 		test
 			.nock(TEST_UPLOAD_ROOT, api => api
-				.post('/2.0/files/content', function (body) {
-					try
-					{
+				.post('/2.0/files/content', function(body) {
+					try {
 						let lines = body.split(/\r?\n/u);
 						let attributes = JSON.parse(lines[3]);
 						assert.propertyVal(attributes, 'name', testFileName);
 						assert.nestedPropertyVal(attributes, 'parent.id', parentFolderId);
 						assert.equal(lines[8], testFileContent);
-					}
-					catch (error)
-					{
+					} catch (error) {
 						return false;
 					}
 					return true;
@@ -1687,17 +1678,14 @@ describe('Files', () => {
 			});
 		test
 			.nock(TEST_UPLOAD_ROOT, api => api
-				.post('/2.0/files/content', function (body) {
-					try
-					{
+				.post('/2.0/files/content', function(body) {
+					try {
 						let lines = body.split(/\r?\n/u);
 						let attributes = JSON.parse(lines[3]);
 						assert.propertyVal(attributes, 'name', newFileName);
 						assert.nestedPropertyVal(attributes, 'parent.id', parentFolderId);
 						assert.equal(lines[8], testFileContent);
-					}
-					catch (error)
-					{
+					} catch (error) {
 						return false;
 					}
 					return true;
@@ -1718,18 +1706,15 @@ describe('Files', () => {
 			});
 		test
 			.nock(TEST_UPLOAD_ROOT, api => api
-				.post('/2.0/files/content', function (body) {
-					try
-					{
+				.post('/2.0/files/content', function(body) {
+					try {
 						let lines = body.split(/\r?\n/u);
 						let attributes = JSON.parse(lines[3]);
 						assert.propertyVal(attributes, 'content_created_at', contentCreatedAt);
 						assert.propertyVal(attributes, 'content_modified_at', contentModifiedAt);
 						assert.nestedPropertyVal(attributes, 'parent.id', parentFolderId);
 						assert.equal(lines[8], testFileContent);
-					}
-					catch (error)
-					{
+					} catch (error) {
 						return false;
 					}
 					return true;
@@ -1778,7 +1763,7 @@ describe('Files', () => {
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
 				.get(fileDownloadUrl)
-				.reply(200, function () {
+				.reply(200, function() {
 					return fs.createReadStream(testFilePath, 'utf8');
 				})
 			)
@@ -1814,7 +1799,7 @@ describe('Files', () => {
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
 				.get(fileDownloadUrl)
-				.reply(200, function () {
+				.reply(200, function() {
 					return fs.createReadStream(testFilePath, 'utf8');
 				})
 			)
@@ -1847,7 +1832,7 @@ describe('Files', () => {
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
 				.get(fileDownloadUrl)
-				.reply(200, function () {
+				.reply(200, function() {
 					return fs.createReadStream(testFilePath, 'utf8');
 				})
 			)
@@ -1879,7 +1864,7 @@ describe('Files', () => {
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
 				.get(fileDownloadUrl)
-				.reply(200, function () {
+				.reply(200, function() {
 					return fs.createReadStream(testFilePath, 'utf8');
 				})
 			)
@@ -1913,7 +1898,7 @@ describe('Files', () => {
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
 				.get(fileDownloadUrl)
-				.reply(200, function () {
+				.reply(200, function() {
 					return fs.createReadStream(testFilePath, 'utf8');
 				})
 			)
@@ -1952,7 +1937,7 @@ describe('Files', () => {
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
 				.get(fileDownloadUrl)
-				.reply(200, function () {
+				.reply(200, function() {
 					return fs.createReadStream(testFilePath, 'utf8');
 				})
 			)
@@ -2008,7 +1993,7 @@ describe('Files', () => {
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
 				.get(fileDownloadUrl)
-				.reply(200, function () {
+				.reply(200, function() {
 					return fs.createReadStream(testFilePath, 'utf8');
 				})
 			)
@@ -2044,7 +2029,7 @@ describe('Files', () => {
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
 				.get(fileDownloadUrl)
-				.reply(200, function () {
+				.reply(200, function() {
 					return fs.createReadStream(testFilePath, 'utf8');
 				})
 			)
@@ -2080,7 +2065,7 @@ describe('Files', () => {
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
 				.get(fileDownloadUrl)
-				.reply(200, function () {
+				.reply(200, function() {
 					return fs.createReadStream(testFilePath, 'utf8');
 				})
 			)
@@ -2114,7 +2099,7 @@ describe('Files', () => {
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
 				.get(fileDownloadUrl)
-				.reply(200, function () {
+				.reply(200, function() {
 					return fs.createReadStream(testFilePath, 'utf8');
 				})
 			)
@@ -2149,7 +2134,7 @@ describe('Files', () => {
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
 				.get(fileDownloadUrl)
-				.reply(200, function () {
+				.reply(200, function() {
 					return fs.createReadStream(testFilePath, 'utf8');
 				})
 			)
@@ -2185,7 +2170,7 @@ describe('Files', () => {
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
 				.get(fileDownloadUrl)
-				.reply(200, function () {
+				.reply(200, function() {
 					return fs.createReadStream(testFilePath, 'utf8');
 				})
 			)
@@ -2243,7 +2228,7 @@ describe('Files', () => {
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
 				.get(downloadUrl)
-				.reply(200, function () {
+				.reply(200, function() {
 					return fs.createReadStream(testFilePath, 'utf8');
 				})
 			)
@@ -2279,7 +2264,7 @@ describe('Files', () => {
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
 				.get(downloadUrl)
-				.reply(200, function () {
+				.reply(200, function() {
 					return fs.createReadStream(testFilePath, 'utf8');
 				})
 			)
@@ -2315,7 +2300,7 @@ describe('Files', () => {
 			)
 			.nock(TEST_DOWNLOAD_ROOT, api => api
 				.get(downloadUrl)
-				.reply(200, function () {
+				.reply(200, function() {
 					return fs.createReadStream(testFilePath, 'utf8');
 				})
 			)

--- a/test/commands/folders.test.js
+++ b/test/commands/folders.test.js
@@ -1017,12 +1017,13 @@ describe('Folders', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get(`/2.0/folders/${folderId}/items`)
-					.query({ usemarker: true })
+					.query({ usemarker: true, limit: 1000 })
 					.reply(200, fixture)
 					.get(`/2.0/folders/${folderId}/items`)
 					.query({
 						usemarker: true,
 						marker: 'page_1_marker',
+						limit: 1000,
 					})
 					.reply(200, fixture2)
 				)
@@ -1044,6 +1045,7 @@ describe('Folders', () => {
 						sort,
 						direction,
 						usemarker: true,
+						limit: 1000
 					})
 					.reply(200, fixture)
 					.get(`/2.0/folders/${folderId}/items`)
@@ -1052,6 +1054,7 @@ describe('Folders', () => {
 						direction,
 						usemarker: true,
 						marker: 'page_1_marker',
+						limit: 1000
 					})
 					.reply(200, fixture2)
 				)
@@ -1074,6 +1077,7 @@ describe('Folders', () => {
 					.query({
 						fields: 'created_at',
 						usemarker: true,
+						limit: 1000
 					})
 					.reply(200, fixture)
 					.get(`/2.0/folders/${folderId}/items`)
@@ -1081,6 +1085,7 @@ describe('Folders', () => {
 						fields: 'created_at',
 						usemarker: true,
 						marker: 'page_1_marker',
+						limit: 1000
 					})
 					.reply(200, fixture2)
 				)

--- a/test/commands/groups.test.js
+++ b/test/commands/groups.test.js
@@ -73,10 +73,12 @@ describe('Groups', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get('/2.0/groups')
+					.query({limit: 1000})
 					.reply(200, fixture)
 					.get('/2.0/groups')
 					.query({
-						offset: 2
+						offset: 2,
+						limit: 1000
 					})
 					.reply(200, fixture2)
 				)
@@ -93,12 +95,13 @@ describe('Groups', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get('/2.0/groups')
-					.query({fields: 'id,name'})
+					.query({fields: 'id,name', limit: 1000})
 					.reply(200, fixture)
 					.get('/2.0/groups')
 					.query({
 						fields: 'id,name',
-						offset: 2
+						offset: 2,
+						limit: 1000
 					})
 					.reply(200, fixture2)
 				)
@@ -114,12 +117,13 @@ describe('Groups', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get('/2.0/groups')
-					.query({filter_term: 'Employees'})
+					.query({filter_term: 'Employees', limit: 1000})
 					.reply(200, fixture)
 					.get('/2.0/groups')
 					.query({
 						filter_term: 'Employees',
-						offset: 2
+						offset: 2,
+						limit: 1000
 					})
 					.reply(200, fixture2)
 				)
@@ -149,10 +153,11 @@ describe('Groups', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get(`/2.0/groups/${groupId}/collaborations`)
+					.query({limit: 1000})
 					.reply(200, fixture)
 					.get(`/2.0/groups/${groupId}/collaborations`)
 					.query({
-						offset: 1
+						offset: 1, limit: 1000
 					})
 					.reply(200, fixture2)
 				)
@@ -170,12 +175,13 @@ describe('Groups', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get(`/2.0/groups/${groupId}/collaborations`)
-					.query({fields: 'item'})
+					.query({fields: 'item', limit: 1000})
 					.reply(200, fixture)
 					.get(`/2.0/groups/${groupId}/collaborations`)
 					.query({
 						fields: 'item',
-						offset: 1
+						offset: 1,
+						limit: 1000
 					})
 					.reply(200, fixture2)
 				)
@@ -438,10 +444,12 @@ describe('Groups', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get(`/2.0/groups/${groupId}/memberships`)
+					.query({limit: 1000})
 					.reply(200, fixture)
 					.get(`/2.0/groups/${groupId}/memberships`)
 					.query({
-						offset: 1
+						offset: 1,
+						limit: 1000
 					})
 					.reply(200, fixture2)
 				)
@@ -459,12 +467,13 @@ describe('Groups', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get(`/2.0/groups/${groupId}/memberships`)
-					.query({fields: 'user'})
+					.query({fields: 'user', limit: 1000})
 					.reply(200, fixture)
 					.get(`/2.0/groups/${groupId}/memberships`)
 					.query({
 						fields: 'user',
-						offset: 1
+						offset: 1,
+						limit: 1000
 					})
 					.reply(200, fixture2)
 				)

--- a/test/commands/legal-hold-policies.test.js
+++ b/test/commands/legal-hold-policies.test.js
@@ -240,6 +240,7 @@ describe('Legal Hold Policies', () => {
 		test
 			.nock(TEST_API_ROOT, api => api
 				.get('/2.0/legal_hold_policies')
+				.query({limit: 1000})
 				.reply(200, fixture)
 			)
 			.stdout()
@@ -255,6 +256,7 @@ describe('Legal Hold Policies', () => {
 		test
 			.nock(TEST_API_ROOT, api => api
 				.get('/2.0/legal_hold_policies')
+				.query({limit: 1000})
 				.reply(200, fixture)
 			)
 			.stdout()
@@ -269,7 +271,7 @@ describe('Legal Hold Policies', () => {
 		test
 			.nock(TEST_API_ROOT, api => api
 				.get('/2.0/legal_hold_policies')
-				.query({ policy_name: policyNameFilter })
+				.query({ policy_name: policyNameFilter, limit: 1000 })
 				.reply(200, fixture)
 			)
 			.stdout()
@@ -286,7 +288,7 @@ describe('Legal Hold Policies', () => {
 		test
 			.nock(TEST_API_ROOT, api => api
 				.get('/2.0/legal_hold_policies')
-				.query({fields: 'id'})
+				.query({fields: 'id', limit: 1000})
 				.reply(200, fixture)
 			)
 			.stdout()
@@ -311,13 +313,15 @@ describe('Legal Hold Policies', () => {
 			.nock(TEST_API_ROOT, api => api
 				.get('/2.0/legal_hold_policy_assignments')
 				.query({
-					policy_id: policyId
+					policy_id: policyId,
+					limit: 1000
 				})
 				.reply(200, fixture)
 				.get('/2.0/legal_hold_policy_assignments')
 				.query({
 					policy_id: policyId,
-					marker: 'ZDCE3'
+					marker: 'ZDCE3',
+					limit: 1000
 				})
 				.reply(200, fixture2)
 			)
@@ -339,6 +343,7 @@ describe('Legal Hold Policies', () => {
 					policy_id: policyId,
 					assign_to_type: assignToType,
 					assign_to_id: assignToID,
+					limit: 1000
 				})
 				.reply(200, fixture)
 				.get('/2.0/legal_hold_policy_assignments')
@@ -346,7 +351,8 @@ describe('Legal Hold Policies', () => {
 					policy_id: policyId,
 					assign_to_type: assignToType,
 					assign_to_id: assignToID,
-					marker: 'ZDCE3'
+					marker: 'ZDCE3',
+					limit: 1000
 				})
 				.reply(200, fixture2)
 			)
@@ -368,14 +374,16 @@ describe('Legal Hold Policies', () => {
 				.get('/2.0/legal_hold_policy_assignments')
 				.query({
 					fields: 'id',
-					policy_id: policyId
+					policy_id: policyId,
+					limit: 1000
 				})
 				.reply(200, fixture)
 				.get('/2.0/legal_hold_policy_assignments')
 				.query({
 					fields: 'id',
 					policy_id: policyId,
-					marker: 'ZDCE3'
+					marker: 'ZDCE3',
+					limit: 1000
 				})
 				.reply(200, fixture2)
 			)
@@ -575,13 +583,15 @@ describe('Legal Hold Policies', () => {
 			.nock(TEST_API_ROOT, api => api
 				.get('/2.0/file_version_legal_holds')
 				.query({
-					policy_id: policyId
+					policy_id: policyId,
+					limit: 1000
 				})
 				.reply(200, fixture)
 				.get('/2.0/file_version_legal_holds')
 				.query({
 					policy_id: policyId,
-					marker: 'ZDCE3'
+					marker: 'ZDCE3',
+					limit: 1000
 				})
 				.reply(200, fixture2)
 			)
@@ -601,14 +611,16 @@ describe('Legal Hold Policies', () => {
 				.get('/2.0/file_version_legal_holds')
 				.query({
 					fields: 'id',
-					policy_id: policyId
+					policy_id: policyId,
+					limit: 1000
 				})
 				.reply(200, fixture)
 				.get('/2.0/file_version_legal_holds')
 				.query({
 					fields: 'id',
 					policy_id: policyId,
-					marker: 'ZDCE3'
+					marker: 'ZDCE3',
+					limit: 1000
 				})
 				.reply(200, fixture2)
 			)

--- a/test/commands/metadata-cascade-policies.test.js
+++ b/test/commands/metadata-cascade-policies.test.js
@@ -79,7 +79,7 @@ describe('Metadata Cascade Policies', () => {
 		test
 			.nock(TEST_API_ROOT, api => api
 				.get('/2.0/metadata_cascade_policies')
-				.query({ folder_id: folderID })
+				.query({ folder_id: folderID, limit: 1000 })
 				.reply(200, fixture)
 			)
 			.stdout()
@@ -96,7 +96,7 @@ describe('Metadata Cascade Policies', () => {
 		test
 			.nock(TEST_API_ROOT, api => api
 				.get('/2.0/metadata_cascade_policies')
-				.query({ folder_id: folderID })
+				.query({ folder_id: folderID, limit: 1000 })
 				.reply(200, fixture)
 			)
 			.stdout()
@@ -115,6 +115,7 @@ describe('Metadata Cascade Policies', () => {
 				.query({
 					folder_id: folderID,
 					owner_enterprise_id: enterpriseID,
+					limit: 1000
 				})
 				.reply(200, fixture)
 			)

--- a/test/commands/metadata-templates.test.js
+++ b/test/commands/metadata-templates.test.js
@@ -48,7 +48,7 @@ describe('Metadata Templates', () => {
 			.it('should create cascade policy (YAML Output)', ctx => {
 				assert.equal(ctx.stdout, yamlOutput);
 			});
-		
+
 		test
 			.nock(TEST_API_ROOT, api => api
 				.post('/2.0/metadata_cascade_policies', {scope, templateKey, folder_id: folderID })
@@ -63,9 +63,9 @@ describe('Metadata Templates', () => {
 			])
 			.it('should create cascade policy (command alias)', ctx => {
 				assert.equal(ctx.stdout, yamlOutput);
-			})
+			});
 	});
-	
+
 	describe('metadata-templates:get', () => {
 		let scope = 'enterprise',
 			templateKey = 'testTemplate',

--- a/test/commands/recent-items.test.js
+++ b/test/commands/recent-items.test.js
@@ -14,10 +14,12 @@ describe('Recent Items', () => {
 		test
 			.nock(TEST_API_ROOT, api => api
 				.get('/2.0/recent_items')
+				.query({limit: 1000})
 				.reply(200, fixture)
 				.get('/2.0/recent_items')
 				.query({
-					marker: 'ZDF123'
+					marker: 'ZDF123',
+					limit: 1000
 				})
 				.reply(200, fixture2)
 			)
@@ -34,12 +36,13 @@ describe('Recent Items', () => {
 		test
 			.nock(TEST_API_ROOT, api => api
 				.get('/2.0/recent_items')
-				.query({fields: 'name'})
+				.query({fields: 'name', limit: 1000})
 				.reply(200, fixture)
 				.get('/2.0/recent_items')
 				.query({
 					fields: 'name',
-					marker: 'ZDF123'
+					marker: 'ZDF123',
+					limit: 1000
 				})
 				.reply(200, fixture2)
 			)

--- a/test/commands/retention-policies.test.js
+++ b/test/commands/retention-policies.test.js
@@ -305,10 +305,12 @@ describe('Retention Policies', () => {
 		test
 			.nock(TEST_API_ROOT, api => api
 				.get('/2.0/retention_policies')
+				.query({limit: 1000})
 				.reply(200, fixture)
 				.get('/2.0/retention_policies')
 				.query({
-					marker: 'ZDE345'
+					marker: 'ZDE345',
+					limit: 1000
 				})
 				.reply(200, fixture2)
 			)
@@ -330,6 +332,7 @@ describe('Retention Policies', () => {
 					policy_name: policyName,
 					policy_type: policyType,
 					created_by_user_id: creatorID,
+					limit: 1000
 				})
 				.reply(200, fixture)
 				.get('/2.0/retention_policies')
@@ -338,7 +341,8 @@ describe('Retention Policies', () => {
 					policy_name: policyName,
 					policy_type: policyType,
 					created_by_user_id: creatorID,
-					marker: 'ZDE345'
+					marker: 'ZDE345',
+					limit: 1000
 				})
 				.reply(200, fixture2)
 			)
@@ -547,10 +551,12 @@ describe('Retention Policies', () => {
 		test
 			.nock(TEST_API_ROOT, api => api
 				.get(`/2.0/retention_policies/${policyId}/assignments`)
+				.query({limit: 1000})
 				.reply(200, fixture)
 				.get(`/2.0/retention_policies/${policyId}/assignments`)
 				.query({
-					marker: 'ZDE456'
+					marker: 'ZDE456',
+					limit: 1000
 				})
 				.reply(200, fixture2)
 			)
@@ -568,12 +574,13 @@ describe('Retention Policies', () => {
 		test
 			.nock(TEST_API_ROOT, api => api
 				.get(`/2.0/retention_policies/${policyId}/assignments`)
-				.query({ type })
+				.query({ type, limit: 1000 })
 				.reply(200, fixture)
 				.get(`/2.0/retention_policies/${policyId}/assignments`)
 				.query({
 					type,
-					marker: 'ZDE456'
+					marker: 'ZDE456',
+					limit: 1000
 				})
 				.reply(200, fixture2)
 			)
@@ -592,12 +599,13 @@ describe('Retention Policies', () => {
 		test
 			.nock(TEST_API_ROOT, api => api
 				.get(`/2.0/retention_policies/${policyId}/assignments`)
-				.query({fields: 'assigned_to'})
+				.query({fields: 'assigned_to', limit: 1000})
 				.reply(200, fixture)
 				.get(`/2.0/retention_policies/${policyId}/assignments`)
 				.query({
 					fields: 'assigned_to',
-					marker: 'ZDE456'
+					marker: 'ZDE456',
+					limit: 1000
 				})
 				.reply(200, fixture2)
 			)
@@ -672,10 +680,12 @@ describe('Retention Policies', () => {
 		test
 			.nock(TEST_API_ROOT, api => api
 				.get('/2.0/file_version_retentions')
+				.query({limit: 1000})
 				.reply(200, fixture)
 				.get('/2.0/file_version_retentions')
 				.query({
-					marker: 'ZAD345'
+					marker: 'ZAD345',
+					limit: 1000
 				})
 				.reply(200, fixture2)
 			)
@@ -723,12 +733,13 @@ describe('Retention Policies', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get('/2.0/file_version_retentions')
-					.query(queryParams)
+					.query({...queryParams, limit: 1000})
 					.reply(200, fixture)
 					.get('/2.0/file_version_retentions')
 					.query({
 						...queryParams,
-						marker: 'ZAD345'
+						marker: 'ZAD345',
+						limit: 1000
 					})
 					.reply(200, fixture2)
 				)
@@ -755,10 +766,12 @@ describe('Retention Policies', () => {
 		test
 			.nock(TEST_API_ROOT, api => api
 				.get(`/2.0/retention_policy_assignments/${policyAssignmentId}/files_under_retention`)
+				.query({limit: 1000})
 				.reply(200, fixture)
 				.get(`/2.0/retention_policy_assignments/${policyAssignmentId}/files_under_retention`)
 				.query({
-					marker: 'ZAD345'
+					marker: 'ZAD345',
+					limit: 1000
 				})
 				.reply(200, fixture2)
 			)
@@ -784,10 +797,12 @@ describe('Retention Policies', () => {
 		test
 			.nock(TEST_API_ROOT, api => api
 				.get(`/2.0/retention_policy_assignments/${policyAssignmentId}/file_versions_under_retention`)
+				.query({limit: 1000})
 				.reply(200, fixture)
 				.get(`/2.0/retention_policy_assignments/${policyAssignmentId}/file_versions_under_retention`)
 				.query({
-					marker: 'ZAD345'
+					marker: 'ZAD345',
+					limit: 1000
 				})
 				.reply(200, fixture2)
 			)

--- a/test/commands/search.test.js
+++ b/test/commands/search.test.js
@@ -322,13 +322,13 @@ describe('Search', () => {
 						.get('/2.0/search')
 						.query({
 							query,
-							limit: 100,
+							limit: 1000,
 						})
 						.reply(200, fixture)
 						.get('/2.0/search')
 						.query({
 							query,
-							limit: 100,
+							limit: 1000,
 							offset: 5
 						})
 						.reply(200, fixture2)
@@ -350,7 +350,7 @@ describe('Search', () => {
 						.get('/2.0/search')
 						.query({
 							query,
-							limit: 100,
+							limit: 5
 						})
 						.reply(200, fixture)
 				)
@@ -379,5 +379,5 @@ describe('Search', () => {
 				.it('when both --all and --limit flag provided', ctx => {
 					assert.include(ctx.stderr, '--all and --limit flags cannot be used together.');
 				});
-	});
+		});
 });

--- a/test/commands/storage-policies.test.js
+++ b/test/commands/storage-policies.test.js
@@ -58,10 +58,12 @@ describe('Storage-policies', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get('/2.0/storage_policies')
+					.query({limit: 1000})
 					.reply(200, fixture)
 					.get('/2.0/storage_policies')
 					.query({
-						marker: 'ZDE789'
+						marker: 'ZDE789',
+						limit: 1000
 					})
 					.reply(200, fixture2)
 				)

--- a/test/commands/trash.test.js
+++ b/test/commands/trash.test.js
@@ -48,10 +48,13 @@ describe('Trash', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get('/2.0/folders/trash/items')
+					.query({usemarker: true, limit: 1000})
 					.reply(200, fixture)
 					.get('/2.0/folders/trash/items')
 					.query({
-						offset: 2
+						offset: 2,
+						usemarker: true,
+						limit: 1000
 					})
 					.reply(200, fixture2)
 				)
@@ -68,12 +71,14 @@ describe('Trash', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get('/2.0/folders/trash/items')
-					.query({fields: 'name'})
+					.query({fields: 'name', usemarker: true, limit: 1000})
 					.reply(200, fixture)
 					.get('/2.0/folders/trash/items')
 					.query({
 						fields: 'name',
-						offset: 2
+						offset: 2,
+						usemarker: true,
+						limit: 1000
 					})
 					.reply(200, fixture2)
 				)

--- a/test/commands/users.test.js
+++ b/test/commands/users.test.js
@@ -216,12 +216,14 @@ describe('Users', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get('/2.0/users')
-					.query({ filter_term: 'AppUser_' })
+					.query({ filter_term: 'AppUser_', usemarker: true, limit: 1000 })
 					.reply(200, fixture)
 					.get('/2.0/users')
 					.query({
 						filter_term: 'AppUser_',
-						offset: 3
+						offset: 3,
+						usemarker: true,
+						limit: 1000,
 					})
 					.reply(200, fixture2)
 				)
@@ -239,12 +241,14 @@ describe('Users', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get('/2.0/users')
-					.query({fields: 'name,address'})
+					.query({fields: 'name,address', usemarker: true, limit: 1000})
 					.reply(200, fixture)
 					.get('/2.0/users')
 					.query({
 						fields: 'name,address',
-						offset: 3
+						offset: 3,
+						usemarker: true,
+						limit: 1000
 					})
 					.reply(200, fixture2)
 				)
@@ -273,10 +277,12 @@ describe('Users', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get(`/2.0/users/${userId}/memberships`)
+					.query({limit: 1000})
 					.reply(200, fixture)
 					.get(`/2.0/users/${userId}/memberships`)
 					.query({
-						offset: 1
+						offset: 1,
+						limit: 1000
 					})
 					.reply(200, fixture2)
 				)
@@ -294,12 +300,13 @@ describe('Users', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get(`/2.0/users/${userId}/memberships`)
-					.query({fields: 'name'})
+					.query({fields: 'name', limit: 1000})
 					.reply(200, fixture)
 					.get(`/2.0/users/${userId}/memberships`)
 					.query({
 						fields: 'name',
-						offset: 1
+						offset: 1,
+						limit: 1000
 					})
 					.reply(200, fixture2)
 				)

--- a/test/commands/webhooks.test.js
+++ b/test/commands/webhooks.test.js
@@ -58,10 +58,12 @@ describe('Webhooks', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get('/2.0/webhooks')
+					.query({limit: 1000})
 					.reply(200, fixture)
 					.get('/2.0/webhooks')
 					.query({
-						marker: 'ZmlQZS0xLTE%3D'
+						marker: 'ZmlQZS0xLTE%3D',
+						limit: 1000
 					})
 					.reply(200, fixture2)
 				)

--- a/test/fixtures/output/files_versions_list_pagination_json.txt
+++ b/test/fixtures/output/files_versions_list_pagination_json.txt
@@ -1,0 +1,36 @@
+[
+    {
+        "type": "file_version",
+        "id": "11111",
+        "sha1": "97cc02de7c356f94e3beeb1e0c63f78a6edb01fd",
+        "name": "test file.txt",
+        "size": 16,
+        "created_at": "2016-12-07T15:59:32-08:00",
+        "modified_at": "2016-12-07T15:59:32-08:00",
+        "modified_by": {
+            "type": "user",
+            "id": "33333",
+            "name": "Test User",
+            "login": "testuser@example.com"
+        },
+        "trashed_at": null,
+        "purged_at": null
+    },
+    {
+        "type": "file_version",
+        "id": "22222",
+        "sha1": "6afc05eae22e994f1c7dd48e58f8895dd9028223",
+        "name": "test file.txt",
+        "size": 9,
+        "created_at": "2016-12-07T15:53:59-08:00",
+        "modified_at": "2016-12-07T15:53:59-08:00",
+        "modified_by": {
+            "type": "user",
+            "id": "33333",
+            "name": "Test User",
+            "login": "testuser@example.com"
+        },
+        "trashed_at": null,
+        "purged_at": null
+    }
+]

--- a/test/fixtures/output/folders_list_items_pagination_json.txt
+++ b/test/fixtures/output/folders_list_items_pagination_json.txt
@@ -1,0 +1,22 @@
+[
+    {
+        "type": "folder",
+        "id": "11111",
+        "sequence_id": "0",
+        "etag": "0",
+        "name": "SDK Test Folder"
+    },
+    {
+        "type": "file",
+        "id": "22222",
+        "file_version": {
+            "type": "file_version",
+            "id": "222220",
+            "sha1": "97cc02de7c356f94e3beeb1e0c63f78a6edb01fd"
+        },
+        "sequence_id": "9",
+        "etag": "9",
+        "sha1": "97cc02de7c356f94e3beeb1e0c63f78a6edb01fd",
+        "name": "test file.txt"
+    }
+]

--- a/test/fixtures/output/folders_list_items_pagination_one_item_json.txt
+++ b/test/fixtures/output/folders_list_items_pagination_one_item_json.txt
@@ -1,0 +1,9 @@
+[
+    {
+        "type": "folder",
+        "id": "11111",
+        "sequence_id": "0",
+        "etag": "0",
+        "name": "SDK Test Folder"
+    }
+]

--- a/test/fixtures/pagination/get_files_id_versions_marker.json
+++ b/test/fixtures/pagination/get_files_id_versions_marker.json
@@ -1,0 +1,42 @@
+{
+    "total_count": 2,
+    "entries": [
+        {
+            "type": "file_version",
+            "id": "11111",
+            "sha1": "97cc02de7c356f94e3beeb1e0c63f78a6edb01fd",
+            "name": "test file.txt",
+            "size": 16,
+            "created_at": "2016-12-07T15:59:32-08:00",
+            "modified_at": "2016-12-07T15:59:32-08:00",
+            "modified_by": {
+                "type": "user",
+                "id": "33333",
+                "name": "Test User",
+                "login": "testuser@example.com"
+            },
+            "trashed_at": null,
+            "purged_at": null
+        },
+        {
+            "type": "file_version",
+            "id": "22222",
+            "sha1": "6afc05eae22e994f1c7dd48e58f8895dd9028223",
+            "name": "test file.txt",
+            "size": 9,
+            "created_at": "2016-12-07T15:53:59-08:00",
+            "modified_at": "2016-12-07T15:53:59-08:00",
+            "modified_by": {
+                "type": "user",
+                "id": "33333",
+                "name": "Test User",
+                "login": "testuser@example.com"
+            },
+            "trashed_at": null,
+            "purged_at": null
+        }
+    ],
+    "limit": 2,
+    "offset": 0,
+    "marker": null
+}

--- a/test/fixtures/pagination/get_folders_id_items_marker.json
+++ b/test/fixtures/pagination/get_folders_id_items_marker.json
@@ -1,0 +1,36 @@
+{
+    "total_count": 2,
+    "entries": [
+        {
+            "type": "folder",
+            "id": "11111",
+            "sequence_id": "0",
+            "etag": "0",
+            "name": "SDK Test Folder"
+        },
+        {
+            "type": "file",
+            "id": "22222",
+            "file_version": {
+                "type": "file_version",
+                "id": "222220",
+                "sha1": "97cc02de7c356f94e3beeb1e0c63f78a6edb01fd"
+            },
+            "sequence_id": "9",
+            "etag": "9",
+            "sha1": "97cc02de7c356f94e3beeb1e0c63f78a6edb01fd",
+            "name": "test file.txt"
+        }
+    ],
+    "marker": null,
+    "order": [
+        {
+            "by": "type",
+            "direction": "ASC"
+        },
+        {
+            "by": "name",
+            "direction": "ASC"
+        }
+    ]
+}

--- a/test/pagination-utils.test.js
+++ b/test/pagination-utils.test.js
@@ -1,0 +1,168 @@
+'use strict';
+
+const paginationUtils = require('../src/pagination-utils');
+const assert = require('chai').assert;
+const { test } = require('@oclif/test');
+const { getFixture, TEST_API_ROOT } = require('./helpers/test-helper');
+
+describe('Pagination', () => {
+	describe('Utilities', () => {
+		it('should set limit to flag value', () => {
+			let flags = { 'max-items': 42 };
+			let options = paginationUtils.handlePagination(flags);
+			assert.deepEqual(options, { limit: 42 });
+		});
+
+		it('should set limit to maximum value of 1000', () => {
+			let flags = { 'max-items': 420000 };
+			let options = paginationUtils.handlePagination(flags);
+			assert.deepEqual(options, { limit: 1000 });
+		});
+
+		it('should throw exception if max-items is equal to 0', () => {
+			let flags = { 'max-items': 0 };
+			assert.throws(
+				() => paginationUtils.handlePagination(flags),
+				'Max items must be greater than 0'
+			);
+		});
+
+		it('should throw exception if max-items is less than 0', () => {
+			let flags = { 'max-items': -100 };
+			assert.throws(
+				() => paginationUtils.handlePagination(flags),
+				'Max items must be greater than 0'
+			);
+		});
+
+		it('should set default limit to 1000', () => {
+			let flags = {};
+			let options = paginationUtils.handlePagination(flags);
+			assert.deepEqual(options, { limit: 1000 });
+		});
+
+		it('should set usemarker to true', () => {
+			let flags = {};
+			let options = paginationUtils.forceMarkerPagination(flags);
+			assert.deepEqual(options, { usemarker: true, limit: 1000 });
+		});
+
+		it('flags contain max-items', () => {
+			assert.containsAllKeys(paginationUtils.flags, 'max-items');
+		});
+	});
+
+	describe('Endpoints query parameterers', () => {
+		describe('Pagination', () => {
+			let fixture = getFixture('pagination/get_files_id_versions_marker.json'),
+				jsonOutput = getFixture(
+					'output/files_versions_list_pagination_json.txt'
+				),
+				fileId = '1234567890';
+
+			test
+				.nock(TEST_API_ROOT, (api) =>
+					api
+						.get(`/2.0/files/${fileId}/versions`)
+						.query({ limit: 2 })
+						.reply(200, fixture)
+				)
+				.stdout()
+				.command([
+					'files:versions',
+					fileId,
+					'--token=test',
+					'--json',
+					'--max-items=2',
+				])
+				.it('should include max-items as limit and return response', (ctx) => {
+					assert.equal(ctx.stdout, jsonOutput);
+				});
+		});
+
+		describe('Forced marker pagination', () => {
+			let fixture = getFixture('pagination/get_folders_id_items_marker'),
+				jsonOutput = getFixture(
+					'output/folders_list_items_pagination_json.txt'
+				),
+				folderId = '0';
+
+			test
+				.nock(TEST_API_ROOT, (api) =>
+					api
+						.get(`/2.0/folders/${folderId}/items`)
+						.query({ usemarker: true, limit: 2 })
+						.reply(200, fixture)
+				)
+				.stdout()
+				.command([
+					'folders:items',
+					folderId,
+					'--token=test',
+					'--json',
+					'--max-items=2',
+				])
+				.it(
+					'should include max-items as limit, usemarker set to true and return response',
+					(ctx) => {
+						assert.equal(ctx.stdout, jsonOutput);
+					}
+				);
+		});
+
+		describe('Max items', () => {
+			let fixture = getFixture('pagination/get_folders_id_items_marker.json'),
+				oneItemJsonOutput = getFixture(
+					'output/folders_list_items_pagination_one_item_json.txt'
+				),
+				twoItemsJsonOutput = getFixture(
+					'output/folders_list_items_pagination_json.txt'
+				),
+				folderId = '0';
+
+			test
+				.nock(TEST_API_ROOT, (api) =>
+					api
+						.get(`/2.0/folders/${folderId}/items`)
+						.query({ usemarker: true, limit: 1 })
+						.reply(200, fixture)
+				)
+				.stdout()
+				.command([
+					'folders:items',
+					folderId,
+					'--token=test',
+					'--json',
+					'--max-items=1',
+				])
+				.it(
+					'should return number of items up to max-items if max-items is smaller than the result length',
+					(ctx) => {
+						assert.equal(ctx.stdout, oneItemJsonOutput);
+					}
+				);
+
+			test
+				.nock(TEST_API_ROOT, (api) =>
+					api
+						.get(`/2.0/folders/${folderId}/items`)
+						.query({ usemarker: true, limit: 3 })
+						.reply(200, fixture)
+				)
+				.stdout()
+				.command([
+					'folders:items',
+					folderId,
+					'--token=test',
+					'--json',
+					'--max-items=3',
+				])
+				.it(
+					'should return number of items up to total number of items if max-items is greater than the result length',
+					(ctx) => {
+						assert.equal(ctx.stdout, twoItemsJsonOutput);
+					}
+				);
+		});
+	});
+});


### PR DESCRIPTION
Added max-items flag that could be used to limit number of items returned by list endpoints. Most of them should support this flag.
Improved performance of list endpoints by providing limit of 1000 by default (instead of 100 which is used by the backend if no limit is provided).

Tests for GetFolderItems for 11k records
Before: avg 133s
After: avg 85s