### PR TITLE
chore: Override `leche` package conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,5 +141,10 @@
 		"build": "oclif-dev pack:macos && rm -rf tmp/ && oclif-dev pack:win && rm -rf tmp/ && npm run binaries",
 		"binaries": "pkg --targets node12-macos-x64,node12-win-x64,node12-linux-x64 --out-path ./dist .",
 		"changelog": "node node_modules/standard-version/bin/cli.js --skip.commit --skip.push --skip.tag --dry-run"
+	},
+	"overrides": {
+		"leche": {
+			"mocha": ">=1.18"
+		}
 	}
 }


### PR DESCRIPTION
[`leche`](https://www.npmjs.com/package/leche) package is a package written by Box but it's deprecated for now. It have some conflict with `mocha` testing library, and specifying that not supporting the latest version of `mocha`, while still pass the unit tests.

This override remove the upper bound limit of `mocha` version which `leche` compatible.