### PR TITLE
fix: force offset based pagination in get users

### DIFF
--- a/src/modules/user.js
+++ b/src/modules/user.js
@@ -37,11 +37,11 @@ class UserModule {
 			options.user_type = 'external';
 		}
 
-		//forcing offset based pagination for now. Using filter_term causes infinite loop because next_marker is never null
-		// if (flags.limit) {
-		// 	options.limit = flags.limit;
-		// }
+		if (flags.limit) {
+			options.limit = flags.limit;
+		}
 
+		//forcing offset based pagination for now. Using filter_term causes infinite loop because next_marker is never null
 		// if (flags.usemarker) {
 		// 	options.usemarker = flags.usemarker;
 		// }

--- a/src/modules/user.js
+++ b/src/modules/user.js
@@ -37,13 +37,14 @@ class UserModule {
 			options.user_type = 'external';
 		}
 
-		if (flags.limit) {
-			options.limit = flags.limit;
-		}
+		//forcing offset based pagination for now. Using filter_term causes infinite loop because next_marker is never null
+		// if (flags.limit) {
+		// 	options.limit = flags.limit;
+		// }
 
-		if (flags.usemarker) {
-			options.usemarker = flags.usemarker;
-		}
+		// if (flags.usemarker) {
+		// 	options.usemarker = flags.usemarker;
+		// }
 
 		if (flags.filter) {
 			options.filter_term = flags.filter;

--- a/test/commands/users.test.js
+++ b/test/commands/users.test.js
@@ -216,13 +216,12 @@ describe('Users', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get('/2.0/users')
-					.query({ filter_term: 'AppUser_', usemarker: true, limit: 1000 })
+					.query({ filter_term: 'AppUser_', limit: 1000 })
 					.reply(200, fixture)
 					.get('/2.0/users')
 					.query({
 						filter_term: 'AppUser_',
 						offset: 3,
-						usemarker: true,
 						limit: 1000,
 					})
 					.reply(200, fixture2)
@@ -241,13 +240,12 @@ describe('Users', () => {
 			test
 				.nock(TEST_API_ROOT, api => api
 					.get('/2.0/users')
-					.query({fields: 'name,address', usemarker: true, limit: 1000})
+					.query({fields: 'name,address', limit: 1000})
 					.reply(200, fixture)
 					.get('/2.0/users')
 					.query({
 						fields: 'name,address',
 						offset: 3,
-						usemarker: true,
 						limit: 1000
 					})
 					.reply(200, fixture2)


### PR DESCRIPTION
Changing back marker-based pagination to the offset one in GET /users as it causes infinite loop (next_marker is never null) when using together with `filter_term`.

Need to clarify with service owners as it looks like an API bug, because the next_marker should be null at some point to indicate the end of the result set.

> The final page of items has been requested when the next next_marker value is null in the response object. At this point there are no more items to fetch.

https://developer.box.com/guides/api-calls/pagination/marker-based/

