### PR TITLE
fix: Fix `configure:environments:set-current` command

### DIFF
--- a/src/commands/configure/environments/add.js
+++ b/src/commands/configure/environments/add.js
@@ -93,8 +93,9 @@ class EnvironmentsAddCommand extends BoxCommand {
 			newEnvironment.hasInLinePrivateKey = false;
 		}
 		if (flags['set-as-current']) {
-			configObj.default = args.name;
+			environmentsObj.default = environmentName;
 		}
+
 		// If no default environment is defined, this newly added environment will be set as the default
 		if (!environmentsObj.default) {
 			environmentsObj.default = environmentName;

--- a/src/commands/configure/environments/set-current.js
+++ b/src/commands/configure/environments/set-current.js
@@ -8,7 +8,7 @@ class EnvironmentsSetCurrentCommand extends BoxCommand {
 	async run() {
 		const { args } = await this.parse(EnvironmentsSetCurrentCommand);
 		let environmentsObj = await this.getEnvironments();
-		let name = args.name;
+		let name = args.id;
 
 		if (!name) {
 			let answers = await inquirer.prompt([
@@ -44,7 +44,7 @@ EnvironmentsSetCurrentCommand.flags = {
 
 EnvironmentsSetCurrentCommand.args = {
 	id: Args.string({
-		name: 'name',
+		name: 'id',
 		required: false,
 		hidden: false,
 		description: 'Name of the environment'


### PR DESCRIPTION
This PR fixes setting current environment.

Previously `configure:environment:set-current` wasn't work because bad parameter was used internally.
Instead using `args.id` the `args.name` was used which was had unassigned value. As a result, even if the user passed the value, it wasn't detected and user had to choose env from the list.

The second issue was with adding new environment via `configure:environment:add` command and setting `set-as-current` flag.
To set created environment as a current we have to save it to environmentsObject and store this by using `await this.updateEnvironments(environmentsObj)`, like we do in set-current.
