### PR TITLE
feat: Support `owned-by` flag when moving folder

### DIFF
--- a/src/commands/folders/move.js
+++ b/src/commands/folders/move.js
@@ -16,6 +16,12 @@ class FoldersMoveCommand extends BoxCommand {
 			updates.etag = flags.etag;
 		}
 
+		if (flags['owned-by']) {
+			updates.owned_by = {
+				id: flags['owned-by'],
+			};
+		}
+
 		let movedFolder = await this.client.folders.update(args.id, updates);
 		await this.output(movedFolder);
 	}
@@ -28,6 +34,7 @@ FoldersMoveCommand._endpoint = 'put_folders_id move';
 FoldersMoveCommand.flags = {
 	...BoxCommand.flags,
 	etag: Flags.string({ description: 'Only move if etag value matches' }),
+	'owned-by': Flags.string({ description: 'ID of the user to own the folder' }),
 };
 
 FoldersMoveCommand.args = {

--- a/test/commands/folders.test.js
+++ b/test/commands/folders.test.js
@@ -136,12 +136,21 @@ describe('Folders', () => {
 	describe('folders:move', () => {
 		let folderId = '0',
 			parentFolderId = '987654321',
+			ownedById = '1234567890',
 			moveFixture = getFixture('folders/put_folders_id'),
 			yamlOutput = getFixture('output/folders_move_yaml.txt');
 
 		let moveBody = {
 			parent: {
 				id: parentFolderId
+			}
+		},
+		moveBodyWithOwnedBy = {
+			parent: {
+				id: parentFolderId
+			},
+			owned_by: {
+				id: ownedById
 			}
 		};
 
@@ -204,6 +213,24 @@ describe('Folders', () => {
 			.it('should send If-Match header and throw error when etag flag is passed but does not match', ctx => {
 				let msg = 'Unexpected API Response [412 Precondition Failed | 1wne91fxf8871ide] precondition_failed - The resource has been modified. Please retrieve the resource again and retry';
 				assert.equal(ctx.stderr, `${msg}${os.EOL}`);
+			});
+
+		test
+			.nock(TEST_API_ROOT, api => api
+				.put(`/2.0/folders/${folderId}`, moveBodyWithOwnedBy)
+				.reply(200, moveFixture)
+			)
+			.stdout()
+			.command([
+				'folders:move',
+				folderId,
+				parentFolderId,
+				`--owned-by=${ownedById}`,
+				'--json',
+				'--token=test'
+			])
+			.it('should move a folder to a different folder and set the owner', ctx => {
+				assert.equal(ctx.stdout, moveFixture);
 			});
 	});
 


### PR DESCRIPTION
Add flag for resolving this issue: https://developer.box.com/guides/folders/single/move/#moving-a-subfolder-to-a-private-folder