### PR TITLE
test: Adjust tests to work with form-data 4.0.4

### DIFF
--- a/test/commands/files.test.js
+++ b/test/commands/files.test.js
@@ -1496,17 +1496,17 @@ describe('Files', () => {
 				.post(`/2.0/files/${fileId}/content`, function(body) {
 					try {
 						let lines = body.split(/\r?\n/u);
-						assert.match(lines[0], /^-+\d+$/u);
+						assert.match(lines[0], /^-+[a-f0-9]+$/u);
 						assert.equal(lines[1], 'Content-Disposition: form-data; name="attributes"');
 						assert.equal(lines[2], '');
 						let attributes = JSON.parse(lines[3]);
 						assert.propertyVal(attributes, 'name', testFileName);
-						assert.match(lines[4], /^-+\d+$/u);
+						assert.match(lines[4], /^-+[a-f0-9]+$/u);
 						assert.equal(lines[5], 'Content-Disposition: form-data; name="content"; filename="unused"');
 						assert.equal(lines[6], 'Content-Type: text/plain');
 						assert.equal(lines[7], '');
 						assert.equal(lines[8], testFileContent);
-						assert.match(lines[9], /^-+\d+-+$/u);
+						assert.match(lines[9], /^-+[a-f0-9]+-+$/u);
 					} catch (error) {
 						return false;
 					}
@@ -1531,17 +1531,17 @@ describe('Files', () => {
 				.post(`/2.0/files/${fileId}/content`, function(body) {
 					try {
 						let lines = body.split(/\r?\n/u);
-						assert.match(lines[0], /^-+\d+$/u);
+						assert.match(lines[0], /^-+[a-f0-9]+$/u);
 						assert.equal(lines[1], 'Content-Disposition: form-data; name="attributes"');
 						assert.equal(lines[2], '');
 						let attributes = JSON.parse(lines[3]);
 						assert.propertyVal(attributes, 'name', testFileName);
-						assert.match(lines[4], /^-+\d+$/u);
+						assert.match(lines[4], /^-+[a-f0-9]+$/u);
 						assert.equal(lines[5], 'Content-Disposition: form-data; name="content"; filename="unused"');
 						assert.equal(lines[6], 'Content-Type: text/plain');
 						assert.equal(lines[7], '');
 						assert.equal(lines[8], testFileContent);
-						assert.match(lines[9], /^-+\d+-+$/u);
+						assert.match(lines[9], /^-+[a-f0-9]+-+$/u);
 					} catch (error) {
 						return false;
 					}


### PR DESCRIPTION
The PR https://github.com/box/boxcli/pull/586  which bumping the form-data to version 4.0.4 (because of critical vulnerabilit) breaks the existing tests. This is because they changed the way how the boundary is [calculated](https://github.com/form-data/form-data/commit/3d1723080e6577a66f17f163ecd345a21d8d0fd0#diff-3e43d32fd2883fc8300dbf75f467758665f0be79f3e26f4b2c7dfcfe69496e23L348-R349).

In order to fix the tests we have to change the boundary regex from /^-+\d+$/ to /^-+[a-f0-9]+$/
