### PR TITLE
fix: Fix `--exempt-from-2fa` flag in `create` and `update` users and commands

### DIFF
--- a/src/commands/users/create.js
+++ b/src/commands/users/create.js
@@ -20,7 +20,7 @@ class UsersCreateCommand extends BoxCommand {
 			options.is_exempt_from_device_limits = flags['exempt-from-device-limits'];
 		}
 		if (flags.hasOwnProperty('exempt-from-2fa')) {
-			options.is_exempt_login_verification = flags['exempt-from-2fa'];
+			options.is_exempt_from_login_verification = flags['exempt-from-2fa'];
 		}
 		if (flags.hasOwnProperty('restrict-external-collab')) {
 			options.is_external_collab_restricted = flags['restrict-external-collab'];

--- a/src/commands/users/update.js
+++ b/src/commands/users/update.js
@@ -18,7 +18,7 @@ class UsersUpdateCommand extends BoxCommand {
 			updates.is_exempt_from_device_limits = flags['exempt-from-device-limits'];
 		}
 		if (flags.hasOwnProperty('exempt-from-2fa')) {
-			updates.is_exempt_login_verification = flags['exempt-from-2fa'];
+			updates.is_exempt_from_login_verification = flags['exempt-from-2fa'];
 		}
 		if (flags.hasOwnProperty('restrict-external-collab')) {
 			updates.is_external_collab_restricted = flags['restrict-external-collab'];

--- a/test/commands/users.test.js
+++ b/test/commands/users.test.js
@@ -659,11 +659,11 @@ describe('Users', () => {
 			],
 			'exempt from login verification flag': [
 				'--exempt-from-2fa',
-				{is_exempt_login_verification: true}
+				{is_exempt_from_login_verification: true}
 			],
 			'no exempt from login verification flag': [
 				'--no-exempt-from-2fa',
-				{is_exempt_login_verification: false}
+				{is_exempt_from_login_verification: false}
 			],
 			'external collab restricted flag': [
 				'--restrict-external-collab',
@@ -842,11 +842,11 @@ describe('Users', () => {
 			],
 			'exempt from login verification flag': [
 				'--exempt-from-2fa',
-				{is_exempt_login_verification: true}
+				{is_exempt_from_login_verification: true}
 			],
 			'no exempt from login verification flag': [
 				'--no-exempt-from-2fa',
-				{is_exempt_login_verification: false}
+				{is_exempt_from_login_verification: false}
 			],
 			'external collab restricted flag': [
 				'--restrict-external-collab',


### PR DESCRIPTION
In `users` update and create command we had bad field mapping. 
Instead of using the `is_exempt_from_login_verification` field we had `is_exempt_login_verification` and as a result this parameter doesn't have any impact. 


As a reference I'm putting here link for this our public docs:
https://developer.box.com/reference/post-users/#param-is_exempt_from_login_verification