### PR TITLE
feat: Add support for `Box Hubs` endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Avatar URL: 'https://app.box.com/api/avatar/large/77777'
 * [`box folders`](docs/folders.md) - Manage folders
 * [`box groups`](docs/groups.md) - List all groups
 * [`box help`](docs/help.md) - Display help for the Box CLI
+* [`box hubs`](docs/hubs.md) - List Box Hubs for the current user
 * [`box integration-mappings`](docs/integration-mappings.md) - List Slack integration mappings
 * [`box legal-hold-policies`](docs/legal-hold-policies.md) - List legal hold policies
 * [`box login`](docs/login.md) - Sign in with OAuth 2.0 and create a new environment (or update an existing one with --reauthorize).

--- a/docs/files.md
+++ b/docs/files.md
@@ -833,12 +833,13 @@ Update the metadata attached to a file
 USAGE
   $ box files:metadata:update ID --template-key <value> [-t <value>] [--as-user <value>] [--no-color] [--json | --csv] [-s
     | --save-to-file-path <value>] [--fields <value>] [--bulk-file-path <value>] [-h] [-v] [-y] [-q] [--scope <value>]
-    [-a <value>...] [-c <value>...] [-m <value>...] [--remove <value>...] [--replace <value>...] [-t <value>...]
+    [-a <value>...] [-c <value>...] [-m <value>...] [--remove <value>...] [--replace <value>...] [-T <value>...]
 
 ARGUMENTS
   ID  ID of the file to update metadata on
 
 FLAGS
+  -T, --test=<value>...            Test that a metadata key contains a specific value; must be in the form key=value
   -a, --add=<value>...             Add a key to the metadata document; must be in the form key=value
   -c, --copy=<value>...            Copy a metadata value to another key; must be in the form sourceKey>destinationKey
   -h, --help                       Show CLI help
@@ -846,7 +847,6 @@ FLAGS
                                    sourceKey>destinationKey
   -q, --quiet                      Suppress any non-error output to stderr
   -s, --save                       Save report to default reports folder on disk
-  -t, --test=<value>...            Test that a metadata key contains a specific value; must be in the form key=value
   -t, --token=<value>              Provide a token to perform this call
   -v, --verbose                    Show verbose output, which can be helpful for debugging
   -y, --yes                        Automatically respond yes to all confirmation prompts

--- a/docs/folders.md
+++ b/docs/folders.md
@@ -1018,12 +1018,13 @@ Update the metadata attached to a folder
 USAGE
   $ box folders:metadata:update ID --template-key <value> [-t <value>] [--as-user <value>] [--no-color] [--json | --csv] [-s
     | --save-to-file-path <value>] [--fields <value>] [--bulk-file-path <value>] [-h] [-v] [-y] [-q] [--scope <value>]
-    [-a <value>...] [-c <value>...] [-m <value>...] [--remove <value>...] [--replace <value>...] [-t <value>...]
+    [-a <value>...] [-c <value>...] [-m <value>...] [--remove <value>...] [--replace <value>...] [-T <value>...]
 
 ARGUMENTS
   ID  ID of the folder to update metadata on
 
 FLAGS
+  -T, --test=<value>...            Test that a metadata key contains a specific value; must be in the form key=value
   -a, --add=<value>...             Add a key to the metadata document; must be in the form key=value
   -c, --copy=<value>...            Copy a metadata value to another key; must be in the form sourceKey>destinationKey
   -h, --help                       Show CLI help
@@ -1031,7 +1032,6 @@ FLAGS
                                    sourceKey>destinationKey
   -q, --quiet                      Suppress any non-error output to stderr
   -s, --save                       Save report to default reports folder on disk
-  -t, --test=<value>...            Test that a metadata key contains a specific value; must be in the form key=value
   -t, --token=<value>              Provide a token to perform this call
   -v, --verbose                    Show verbose output, which can be helpful for debugging
   -y, --yes                        Automatically respond yes to all confirmation prompts

--- a/docs/hubs.md
+++ b/docs/hubs.md
@@ -1,0 +1,355 @@
+`box hubs`
+==========
+
+List Box Hubs for the current user
+
+* [`box hubs`](#box-hubs)
+* [`box hubs:copy ID`](#box-hubscopy-id)
+* [`box hubs:create TITLE`](#box-hubscreate-title)
+* [`box hubs:delete ID`](#box-hubsdelete-id)
+* [`box hubs:enterprise`](#box-hubsenterprise)
+* [`box hubs:get ID`](#box-hubsget-id)
+* [`box hubs:list`](#box-hubslist)
+* [`box hubs:update ID`](#box-hubsupdate-id)
+
+## `box hubs`
+
+List Box Hubs for the current user
+
+```
+USAGE
+  $ box hubs [-t <value>] [--as-user <value>] [--no-color] [--json | --csv] [-s | --save-to-file-path
+    <value>] [--fields <value>] [--bulk-file-path <value>] [-h] [-v] [-y] [-q] [--max-items <value>] [--query <value>]
+    [--scope editable|view_only|all] [--sort name|updated_at|last_accessed_at|view_count|relevance] [--direction
+    ASC|DESC]
+
+FLAGS
+  -h, --help                       Show CLI help
+  -q, --quiet                      Suppress any non-error output to stderr
+  -s, --save                       Save report to default reports folder on disk
+  -t, --token=<value>              Provide a token to perform this call
+  -v, --verbose                    Show verbose output, which can be helpful for debugging
+  -y, --yes                        Automatically respond yes to all confirmation prompts
+      --as-user=<value>            Provide an ID for a user
+      --bulk-file-path=<value>     File path to bulk .csv or .json objects
+      --csv                        Output formatted CSV
+      --direction=<option>         Sort direction. One of: ASC, DESC
+                                   <options: ASC|DESC>
+      --fields=<value>             Comma separated list of fields to show
+      --json                       Output formatted JSON
+      --max-items=<value>          A value that indicates the maximum number of results to return. This only specifies a
+                                   maximum boundary and will not guarantee the minimum number of results returned. When
+                                   the max-items (x) is greater than 1000, then the maximum ceil(x/1000) requests will
+                                   be made.
+      --no-color                   Turn off colors for logging
+      --query=<value>              Search query for Box Hubs
+      --save-to-file-path=<value>  Override default file path to save report
+      --scope=<option>             Scope of hubs to retrieve. One of: editable, view_only, all
+                                   <options: editable|view_only|all>
+      --sort=<option>              Sort field for hubs. One of: name, updated_at, last_accessed_at, view_count,
+                                   relevance
+                                   <options: name|updated_at|last_accessed_at|view_count|relevance>
+
+DESCRIPTION
+  List Box Hubs for the current user
+
+ALIASES
+  $ box hubs:list
+
+EXAMPLES
+  $ box hubs
+
+  $ box hubs --query "Product" --scope editable --sort name --direction ASC
+```
+
+_See code: [src/commands/hubs/index.js](https://github.com/box/boxcli/blob/v4.7.0/src/commands/hubs/index.js)_
+
+## `box hubs:copy ID`
+
+Copy a Box Hub
+
+```
+USAGE
+  $ box hubs:copy ID [-t <value>] [--as-user <value>] [--no-color] [--json | --csv] [-s | --save-to-file-path
+    <value>] [--fields <value>] [--bulk-file-path <value>] [-h] [-v] [-y] [-q] [-T <value>] [-d <value>]
+
+ARGUMENTS
+  ID  ID of the Box Hub to copy
+
+FLAGS
+  -T, --title=<value>              Optional title override for the copied hub
+  -d, --description=<value>        Optional description override for the copied hub
+  -h, --help                       Show CLI help
+  -q, --quiet                      Suppress any non-error output to stderr
+  -s, --save                       Save report to default reports folder on disk
+  -t, --token=<value>              Provide a token to perform this call
+  -v, --verbose                    Show verbose output, which can be helpful for debugging
+  -y, --yes                        Automatically respond yes to all confirmation prompts
+      --as-user=<value>            Provide an ID for a user
+      --bulk-file-path=<value>     File path to bulk .csv or .json objects
+      --csv                        Output formatted CSV
+      --fields=<value>             Comma separated list of fields to show
+      --json                       Output formatted JSON
+      --no-color                   Turn off colors for logging
+      --save-to-file-path=<value>  Override default file path to save report
+
+DESCRIPTION
+  Copy a Box Hub
+
+EXAMPLES
+  $ box hubs:copy 12345 --title "Copied hub title" --description "Copied hub description"
+```
+
+_See code: [src/commands/hubs/copy.js](https://github.com/box/boxcli/blob/v4.7.0/src/commands/hubs/copy.js)_
+
+## `box hubs:create TITLE`
+
+Create a new Box Hub
+
+```
+USAGE
+  $ box hubs:create TITLE [-t <value>] [--as-user <value>] [--no-color] [--json | --csv] [-s |
+    --save-to-file-path <value>] [--fields <value>] [--bulk-file-path <value>] [-h] [-v] [-y] [-q] [-d <value>]
+
+ARGUMENTS
+  TITLE  Title for the Box Hub
+
+FLAGS
+  -d, --description=<value>        Description of the Box Hub
+  -h, --help                       Show CLI help
+  -q, --quiet                      Suppress any non-error output to stderr
+  -s, --save                       Save report to default reports folder on disk
+  -t, --token=<value>              Provide a token to perform this call
+  -v, --verbose                    Show verbose output, which can be helpful for debugging
+  -y, --yes                        Automatically respond yes to all confirmation prompts
+      --as-user=<value>            Provide an ID for a user
+      --bulk-file-path=<value>     File path to bulk .csv or .json objects
+      --csv                        Output formatted CSV
+      --fields=<value>             Comma separated list of fields to show
+      --json                       Output formatted JSON
+      --no-color                   Turn off colors for logging
+      --save-to-file-path=<value>  Override default file path to save report
+
+DESCRIPTION
+  Create a new Box Hub
+
+EXAMPLES
+  $ box hubs:create "Roadmap Hub" --description "Q3 planning hub"
+```
+
+_See code: [src/commands/hubs/create.js](https://github.com/box/boxcli/blob/v4.7.0/src/commands/hubs/create.js)_
+
+## `box hubs:delete ID`
+
+Delete a Box Hub
+
+```
+USAGE
+  $ box hubs:delete ID [-t <value>] [--as-user <value>] [--no-color] [--json | --csv] [-s | --save-to-file-path
+    <value>] [--fields <value>] [--bulk-file-path <value>] [-h] [-v] [-y] [-q]
+
+ARGUMENTS
+  ID  ID of the Box Hub to delete
+
+FLAGS
+  -h, --help                       Show CLI help
+  -q, --quiet                      Suppress any non-error output to stderr
+  -s, --save                       Save report to default reports folder on disk
+  -t, --token=<value>              Provide a token to perform this call
+  -v, --verbose                    Show verbose output, which can be helpful for debugging
+  -y, --yes                        Automatically respond yes to all confirmation prompts
+      --as-user=<value>            Provide an ID for a user
+      --bulk-file-path=<value>     File path to bulk .csv or .json objects
+      --csv                        Output formatted CSV
+      --fields=<value>             Comma separated list of fields to show
+      --json                       Output formatted JSON
+      --no-color                   Turn off colors for logging
+      --save-to-file-path=<value>  Override default file path to save report
+
+DESCRIPTION
+  Delete a Box Hub
+
+EXAMPLES
+  $ box hubs:delete 12345
+```
+
+_See code: [src/commands/hubs/delete.js](https://github.com/box/boxcli/blob/v4.7.0/src/commands/hubs/delete.js)_
+
+## `box hubs:enterprise`
+
+List Box Hubs across the enterprise. This call requires an admin or hub co-admin of an enterprise with GCM scope. Otherwise, Box returns a 403 status code with the message `The request requires higher privileges than provided by the access token.` See https://developer.box.com/guides/api-calls/permissions-and-errors/scopes#global-content-manager-gcm
+
+```
+USAGE
+  $ box hubs:enterprise [-t <value>] [--as-user <value>] [--no-color] [--json | --csv] [-s | --save-to-file-path
+    <value>] [--fields <value>] [--bulk-file-path <value>] [-h] [-v] [-y] [-q] [--max-items <value>] [--query <value>]
+    [--sort name|updated_at|last_accessed_at|view_count|relevance] [--direction ASC|DESC]
+
+FLAGS
+  -h, --help                       Show CLI help
+  -q, --quiet                      Suppress any non-error output to stderr
+  -s, --save                       Save report to default reports folder on disk
+  -t, --token=<value>              Provide a token to perform this call
+  -v, --verbose                    Show verbose output, which can be helpful for debugging
+  -y, --yes                        Automatically respond yes to all confirmation prompts
+      --as-user=<value>            Provide an ID for a user
+      --bulk-file-path=<value>     File path to bulk .csv or .json objects
+      --csv                        Output formatted CSV
+      --direction=<option>         Sort direction. One of: ASC, DESC
+                                   <options: ASC|DESC>
+      --fields=<value>             Comma separated list of fields to show
+      --json                       Output formatted JSON
+      --max-items=<value>          A value that indicates the maximum number of results to return. This only specifies a
+                                   maximum boundary and will not guarantee the minimum number of results returned. When
+                                   the max-items (x) is greater than 1000, then the maximum ceil(x/1000) requests will
+                                   be made.
+      --no-color                   Turn off colors for logging
+      --query=<value>              Search query for enterprise Box Hubs
+      --save-to-file-path=<value>  Override default file path to save report
+      --sort=<option>              Sort field for hubs. One of: name, updated_at, last_accessed_at, view_count,
+                                   relevance
+                                   <options: name|updated_at|last_accessed_at|view_count|relevance>
+
+DESCRIPTION
+  List Box Hubs across the enterprise. This call requires an admin or hub co-admin of an enterprise with GCM scope.
+  Otherwise, Box returns a 403 status code with the message `The request requires higher privileges than provided by the
+  access token.` See https://developer.box.com/guides/api-calls/permissions-and-errors/scopes#global-content-manager-gcm
+
+EXAMPLES
+  $ box hubs:enterprise
+
+  $ box hubs:enterprise --query "Roadmap" --sort updated_at --direction DESC
+```
+
+_See code: [src/commands/hubs/enterprise.js](https://github.com/box/boxcli/blob/v4.7.0/src/commands/hubs/enterprise.js)_
+
+## `box hubs:get ID`
+
+Get details for a Box Hub
+
+```
+USAGE
+  $ box hubs:get ID [-t <value>] [--as-user <value>] [--no-color] [--json | --csv] [-s | --save-to-file-path
+    <value>] [--fields <value>] [--bulk-file-path <value>] [-h] [-v] [-y] [-q]
+
+ARGUMENTS
+  ID  ID of the Box Hub
+
+FLAGS
+  -h, --help                       Show CLI help
+  -q, --quiet                      Suppress any non-error output to stderr
+  -s, --save                       Save report to default reports folder on disk
+  -t, --token=<value>              Provide a token to perform this call
+  -v, --verbose                    Show verbose output, which can be helpful for debugging
+  -y, --yes                        Automatically respond yes to all confirmation prompts
+      --as-user=<value>            Provide an ID for a user
+      --bulk-file-path=<value>     File path to bulk .csv or .json objects
+      --csv                        Output formatted CSV
+      --fields=<value>             Comma separated list of fields to show
+      --json                       Output formatted JSON
+      --no-color                   Turn off colors for logging
+      --save-to-file-path=<value>  Override default file path to save report
+
+DESCRIPTION
+  Get details for a Box Hub
+
+EXAMPLES
+  $ box hubs:get 12345
+```
+
+_See code: [src/commands/hubs/get.js](https://github.com/box/boxcli/blob/v4.7.0/src/commands/hubs/get.js)_
+
+## `box hubs:list`
+
+List Box Hubs for the current user
+
+```
+USAGE
+  $ box hubs:list [-t <value>] [--as-user <value>] [--no-color] [--json | --csv] [-s | --save-to-file-path
+    <value>] [--fields <value>] [--bulk-file-path <value>] [-h] [-v] [-y] [-q] [--max-items <value>] [--query <value>]
+    [--scope editable|view_only|all] [--sort name|updated_at|last_accessed_at|view_count|relevance] [--direction
+    ASC|DESC]
+
+FLAGS
+  -h, --help                       Show CLI help
+  -q, --quiet                      Suppress any non-error output to stderr
+  -s, --save                       Save report to default reports folder on disk
+  -t, --token=<value>              Provide a token to perform this call
+  -v, --verbose                    Show verbose output, which can be helpful for debugging
+  -y, --yes                        Automatically respond yes to all confirmation prompts
+      --as-user=<value>            Provide an ID for a user
+      --bulk-file-path=<value>     File path to bulk .csv or .json objects
+      --csv                        Output formatted CSV
+      --direction=<option>         Sort direction. One of: ASC, DESC
+                                   <options: ASC|DESC>
+      --fields=<value>             Comma separated list of fields to show
+      --json                       Output formatted JSON
+      --max-items=<value>          A value that indicates the maximum number of results to return. This only specifies a
+                                   maximum boundary and will not guarantee the minimum number of results returned. When
+                                   the max-items (x) is greater than 1000, then the maximum ceil(x/1000) requests will
+                                   be made.
+      --no-color                   Turn off colors for logging
+      --query=<value>              Search query for Box Hubs
+      --save-to-file-path=<value>  Override default file path to save report
+      --scope=<option>             Scope of hubs to retrieve. One of: editable, view_only, all
+                                   <options: editable|view_only|all>
+      --sort=<option>              Sort field for hubs. One of: name, updated_at, last_accessed_at, view_count,
+                                   relevance
+                                   <options: name|updated_at|last_accessed_at|view_count|relevance>
+
+DESCRIPTION
+  List Box Hubs for the current user
+
+ALIASES
+  $ box hubs:list
+
+EXAMPLES
+  $ box hubs
+
+  $ box hubs --query "Product" --scope editable --sort name --direction ASC
+```
+
+## `box hubs:update ID`
+
+Update a Box Hub
+
+```
+USAGE
+  $ box hubs:update ID [-t <value>] [--as-user <value>] [--no-color] [--json | --csv] [-s | --save-to-file-path
+    <value>] [--fields <value>] [--bulk-file-path <value>] [-h] [-v] [-y] [-q] [-T <value>] [-d <value>] [--ai-enabled]
+    [--collaboration-restricted-to-enterprise] [--can-non-owners-invite] [--can-shared-link-be-created]
+    [--can-public-shared-link-be-created]
+
+ARGUMENTS
+  ID  ID of the Box Hub to update
+
+FLAGS
+  -T, --title=<value>                                Updated title for the Box Hub
+  -d, --description=<value>                          Updated description for the Box Hub
+  -h, --help                                         Show CLI help
+  -q, --quiet                                        Suppress any non-error output to stderr
+  -s, --save                                         Save report to default reports folder on disk
+  -t, --token=<value>                                Provide a token to perform this call
+  -v, --verbose                                      Show verbose output, which can be helpful for debugging
+  -y, --yes                                          Automatically respond yes to all confirmation prompts
+      --[no-]ai-enabled                              Enable or disable AI features for this Box Hub
+      --as-user=<value>                              Provide an ID for a user
+      --bulk-file-path=<value>                       File path to bulk .csv or .json objects
+      --[no-]can-non-owners-invite                   Allow non-owners to invite collaborators
+      --[no-]can-public-shared-link-be-created       Allow public shared links for this Box Hub
+      --[no-]can-shared-link-be-created              Allow shared links for this Box Hub
+      --[no-]collaboration-restricted-to-enterprise  Restrict collaboration to enterprise users only
+      --csv                                          Output formatted CSV
+      --fields=<value>                               Comma separated list of fields to show
+      --json                                         Output formatted JSON
+      --no-color                                     Turn off colors for logging
+      --save-to-file-path=<value>                    Override default file path to save report
+
+DESCRIPTION
+  Update a Box Hub
+
+EXAMPLES
+  $ box hubs:update 12345 --title "Updated title" --ai-enabled
+```
+
+_See code: [src/commands/hubs/update.js](https://github.com/box/boxcli/blob/v4.7.0/src/commands/hubs/update.js)_

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -13,16 +13,16 @@ Get a token. Returns the service account token by default
 
 ```
 USAGE
-  $ box tokens:exchange SCOPE [--no-color] [-h] [-v] [-q] [-u <value> | -t <value>] [--file-id <value> | --folder-id
+  $ box tokens:exchange SCOPE [--no-color] [-h] [-v] [-q] [-u <value> | -T <value>] [--file-id <value> | --folder-id
     <value>]
 
 ARGUMENTS
   SCOPE  The scope(s) for the new token, separated by a comma if multiple are present
 
 FLAGS
+  -T, --token=<value>      Specify the token to exchange
   -h, --help               Show CLI help
   -q, --quiet              Suppress any non-error output to stderr
-  -t, --token=<value>      Specify the token to exchange
   -u, --user-id=<value>    Get a user token from a user ID
   -v, --verbose            Show verbose output, which can be helpful for debugging
       --file-id=<value>    Scope the token to a specific file

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@oclif/table": "^0.4.14",
 				"@octokit/rest": "^22.0.0",
 				"archiver": "^3.0.0",
-				"box-node-sdk": "^4.3.0",
+				"box-node-sdk": "^4.6.0",
 				"chalk": "^2.4.1",
 				"cli-progress": "^2.1.0",
 				"csv": "^6.3.3",
@@ -5762,12 +5762,12 @@
 			"license": "MIT"
 		},
 		"node_modules/box-node-sdk": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/box-node-sdk/-/box-node-sdk-4.3.0.tgz",
-			"integrity": "sha512-CWN9hmnpq5sVXDwc/BKqIZYTRC/Yi4W280YWT5zaiUUgKyujIHsZY3rwtjPfDa7xAQV9FpIplCo9Cm8e57yHtQ==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/box-node-sdk/-/box-node-sdk-4.6.0.tgz",
+			"integrity": "sha512-LrFFYhDq7Tm/I0KCKw+ghgbUsKdF6DEH040tHHd/UylpmqUQ8vQulREXqlTK/ZWfMB5BSSS4pTkB57B1pnCVnQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@cypress/request": "^3.0.9",
+				"@cypress/request": "^3.0.10",
 				"@types/bluebird": "^3.5.35",
 				"@types/node": "^18.15.3",
 				"ajv": "^6.12.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"@oclif/table": "^0.4.14",
 		"@octokit/rest": "^22.0.0",
 		"archiver": "^3.0.0",
-		"box-node-sdk": "^4.3.0",
+		"box-node-sdk": "^4.6.0",
 		"chalk": "^2.4.1",
 		"cli-progress": "^2.1.0",
 		"csv": "^6.3.3",

--- a/src/box-command.js
+++ b/src/box-command.js
@@ -1293,7 +1293,7 @@ class BoxCommand extends Command {
 	 * @returns {Promise<Object[]>} Aggregated marker-based response entries
 	 */
 	async markerPagination(fetchPage, queryParams, maxItemsOverride) {
-		queryParams = queryParams || {};
+		const normalizedQueryParams = queryParams || {};
 		const paginationFlags = {
 			'max-items':
 				maxItemsOverride === undefined
@@ -1308,13 +1308,13 @@ class BoxCommand extends Command {
 				: paginationFlags['max-items'];
 
 		let remaining = maxItems;
-		let entries = [];
+		const entries = [];
 		const pageLimit = paginationOptions.limit;
 		let marker;
 
 		while (remaining > 0) {
-			let pageQueryParams = {
-				...queryParams,
+			const pageQueryParams = {
+				...normalizedQueryParams,
 				limit: Math.min(pageLimit, remaining),
 			};
 

--- a/src/box-command.js
+++ b/src/box-command.js
@@ -30,6 +30,7 @@ const BoxTSSDK = require('box-node-sdk/sdk-gen');
 const BoxTsErrors = require('box-node-sdk/sdk-gen/box/errors');
 const BoxCLIError = require('./cli-error');
 const CLITokenCache = require('./token-cache');
+const PaginationUtilities = require('./pagination-utils');
 const utils = require('./util');
 const pkg = require('../package.json');
 const inquirer = require('./inquirer');
@@ -1281,6 +1282,58 @@ class BoxCommand extends Command {
 	 */
 	maxItemsReached(maxItems, itemsCount) {
 		return maxItems && itemsCount >= maxItems;
+	}
+
+	/**
+	 * Fetch all marker-based pages from a TypeScript SDK endpoint.
+	 *
+	 * @param {Function} fetchPage Callback that receives query params and returns a paged response
+	 * @param {Object} queryParams Base query params for each request
+	 * @param {number} [maxItemsOverride] Optional max items override for advanced use
+	 * @returns {Promise<Object[]>} Aggregated marker-based response entries
+	 */
+	async markerPagination(fetchPage, queryParams, maxItemsOverride) {
+		queryParams = queryParams || {};
+		const paginationFlags = {
+			'max-items':
+				maxItemsOverride === undefined
+					? this.flags['max-items']
+					: maxItemsOverride,
+		};
+		const paginationOptions =
+			PaginationUtilities.handlePagination(paginationFlags);
+		const maxItems =
+			paginationFlags['max-items'] === undefined
+				? paginationOptions.limit
+				: paginationFlags['max-items'];
+
+		let remaining = maxItems;
+		let entries = [];
+		const pageLimit = paginationOptions.limit;
+		let marker;
+
+		while (remaining > 0) {
+			let pageQueryParams = {
+				...queryParams,
+				limit: Math.min(pageLimit, remaining),
+			};
+
+			if (marker) {
+				pageQueryParams.marker = marker;
+			}
+
+			const page = await fetchPage(pageQueryParams);
+			const pageEntries = page.entries || [];
+			entries.push(...pageEntries);
+			remaining -= pageEntries.length;
+			marker = page.nextMarker || page.next_marker;
+
+			if (!marker || pageEntries.length === 0) {
+				break;
+			}
+		}
+
+		return entries;
 	}
 
 	/**

--- a/src/commands/files/metadata/update.js
+++ b/src/commands/files/metadata/update.js
@@ -88,7 +88,7 @@ FilesUpdateMetadataCommand.flags = {
 		parse: utilities.parseMetadataOp,
 	}),
 	test: Flags.string({
-		char: 't',
+		char: 'T',
 		description:
 			'Test that a metadata key contains a specific value; must be in the form key=value',
 		multiple: true,

--- a/src/commands/folders/metadata/update.js
+++ b/src/commands/folders/metadata/update.js
@@ -90,7 +90,7 @@ FoldersUpdateMetadataCommand.flags = {
 		parse: utilities.parseMetadataOp,
 	}),
 	test: Flags.string({
-		char: 't',
+		char: 'T',
 		description:
 			'Test that a metadata key contains a specific value; must be in the form key=value',
 		multiple: true,

--- a/src/commands/hubs/copy.js
+++ b/src/commands/hubs/copy.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const BoxCommand = require('../../box-command');
+const { Flags, Args } = require('@oclif/core');
+const utilities = require('../../util');
+
+class HubsCopyCommand extends BoxCommand {
+	async run() {
+		const { flags, args } = await this.parse(HubsCopyCommand);
+		let requestBody = {};
+
+		if (flags.title) {
+			requestBody.title = flags.title;
+		}
+		if (flags.description) {
+			requestBody.description = flags.description;
+		}
+
+		let hub = await this.tsClient.hubs.copyHubV2025R0(args.id, requestBody);
+		delete hub.rawData;
+		await this.output(hub);
+	}
+}
+
+HubsCopyCommand.description = 'Copy a Box Hub';
+HubsCopyCommand.examples = [
+	'box hubs:copy 12345 --title "Copied hub title" --description "Copied hub description"',
+];
+HubsCopyCommand._endpoint = 'post_hubs_id_copy';
+
+HubsCopyCommand.flags = {
+	...BoxCommand.flags,
+	title: Flags.string({
+		char: 'T',
+		description: 'Optional title override for the copied hub',
+	}),
+	description: Flags.string({
+		char: 'd',
+		description: 'Optional description override for the copied hub',
+		parse: utilities.unescapeSlashes,
+	}),
+};
+
+HubsCopyCommand.args = {
+	id: Args.string({
+		name: 'id',
+		required: true,
+		hidden: false,
+		description: 'ID of the Box Hub to copy',
+	}),
+};
+
+module.exports = HubsCopyCommand;

--- a/src/commands/hubs/copy.js
+++ b/src/commands/hubs/copy.js
@@ -7,7 +7,7 @@ const utilities = require('../../util');
 class HubsCopyCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = await this.parse(HubsCopyCommand);
-		let requestBody = {};
+		const requestBody = {};
 
 		if (flags.title) {
 			requestBody.title = flags.title;
@@ -16,7 +16,7 @@ class HubsCopyCommand extends BoxCommand {
 			requestBody.description = flags.description;
 		}
 
-		let hub = await this.tsClient.hubs.copyHubV2025R0(args.id, requestBody);
+		const hub = await this.tsClient.hubs.copyHubV2025R0(args.id, requestBody);
 		delete hub.rawData;
 		await this.output(hub);
 	}

--- a/src/commands/hubs/create.js
+++ b/src/commands/hubs/create.js
@@ -7,7 +7,7 @@ const utilities = require('../../util');
 class HubsCreateCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = await this.parse(HubsCreateCommand);
-		let requestBody = {
+		const requestBody = {
 			title: args.title,
 		};
 
@@ -15,7 +15,7 @@ class HubsCreateCommand extends BoxCommand {
 			requestBody.description = flags.description;
 		}
 
-		let hub = await this.tsClient.hubs.createHubV2025R0(requestBody);
+		const hub = await this.tsClient.hubs.createHubV2025R0(requestBody);
 		delete hub.rawData;
 		await this.output(hub);
 	}

--- a/src/commands/hubs/create.js
+++ b/src/commands/hubs/create.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const BoxCommand = require('../../box-command');
+const { Flags, Args } = require('@oclif/core');
+const utilities = require('../../util');
+
+class HubsCreateCommand extends BoxCommand {
+	async run() {
+		const { flags, args } = await this.parse(HubsCreateCommand);
+		let requestBody = {
+			title: args.title,
+		};
+
+		if (flags.description) {
+			requestBody.description = flags.description;
+		}
+
+		let hub = await this.tsClient.hubs.createHubV2025R0(requestBody);
+		delete hub.rawData;
+		await this.output(hub);
+	}
+}
+
+HubsCreateCommand.description = 'Create a new Box Hub';
+HubsCreateCommand.examples = ['box hubs:create "Roadmap Hub" --description "Q3 planning hub"'];
+HubsCreateCommand._endpoint = 'post_hubs';
+
+HubsCreateCommand.flags = {
+	...BoxCommand.flags,
+	description: Flags.string({
+		char: 'd',
+		description: 'Description of the Box Hub',
+		parse: utilities.unescapeSlashes,
+	}),
+};
+
+HubsCreateCommand.args = {
+	title: Args.string({
+		name: 'title',
+		required: true,
+		hidden: false,
+		description: 'Title for the Box Hub',
+	}),
+};
+
+module.exports = HubsCreateCommand;

--- a/src/commands/hubs/delete.js
+++ b/src/commands/hubs/delete.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const { Args } = require('@oclif/core');
+const BoxCommand = require('../../box-command');
+
+class HubsDeleteCommand extends BoxCommand {
+	async run() {
+		const { args } = await this.parse(HubsDeleteCommand);
+		await this.tsClient.hubs.deleteHubByIdV2025R0(args.id);
+		this.info(`Deleted hub ${args.id}`);
+	}
+}
+
+HubsDeleteCommand.description = 'Delete a Box Hub';
+HubsDeleteCommand.examples = ['box hubs:delete 12345'];
+HubsDeleteCommand._endpoint = 'delete_hubs_id';
+
+HubsDeleteCommand.flags = {
+	...BoxCommand.flags,
+};
+
+HubsDeleteCommand.args = {
+	id: Args.string({
+		name: 'id',
+		required: true,
+		hidden: false,
+		description: 'ID of the Box Hub to delete',
+	}),
+};
+
+module.exports = HubsDeleteCommand;

--- a/src/commands/hubs/enterprise.js
+++ b/src/commands/hubs/enterprise.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const BoxCommand = require('../../box-command');
+const { Flags } = require('@oclif/core');
+const PaginationUtilities = require('../../pagination-utils');
+
+class HubsEnterpriseListCommand extends BoxCommand {
+	async run() {
+		const { flags } = await this.parse(HubsEnterpriseListCommand);
+		let queryParams = {};
+
+		if (flags.query) {
+			queryParams.query = flags.query;
+		}
+		if (flags.sort) {
+			queryParams.sort = flags.sort;
+		}
+		if (flags.direction) {
+			queryParams.direction = flags.direction;
+		}
+
+		let hubs = await this.markerPagination(
+			(pageQueryParams) =>
+				this.tsClient.hubs.getEnterpriseHubsV2025R0(pageQueryParams),
+			queryParams
+		);
+		await this.output(hubs);
+	}
+}
+
+HubsEnterpriseListCommand.description =
+	'List Box Hubs across the enterprise. This call requires an admin or hub co-admin of an enterprise with GCM scope. Otherwise, Box returns a 403 status code with the message `The request requires higher privileges than provided by the access token.` See https://developer.box.com/guides/api-calls/permissions-and-errors/scopes#global-content-manager-gcm';
+HubsEnterpriseListCommand.examples = [
+	'box hubs:enterprise',
+	'box hubs:enterprise --query "Roadmap" --sort updated_at --direction DESC',
+];
+HubsEnterpriseListCommand._endpoint = 'get_enterprise_hubs';
+
+HubsEnterpriseListCommand.flags = {
+	...BoxCommand.flags,
+	...PaginationUtilities.flags,
+	query: Flags.string({
+		description: 'Search query for enterprise Box Hubs',
+	}),
+	sort: Flags.string({
+		description:
+			'Sort field for hubs. One of: name, updated_at, last_accessed_at, view_count, relevance',
+		options: [
+			'name',
+			'updated_at',
+			'last_accessed_at',
+			'view_count',
+			'relevance',
+		],
+	}),
+	direction: Flags.string({
+		description: 'Sort direction. One of: ASC, DESC',
+		options: ['ASC', 'DESC'],
+	}),
+};
+
+module.exports = HubsEnterpriseListCommand;

--- a/src/commands/hubs/enterprise.js
+++ b/src/commands/hubs/enterprise.js
@@ -7,7 +7,7 @@ const PaginationUtilities = require('../../pagination-utils');
 class HubsEnterpriseListCommand extends BoxCommand {
 	async run() {
 		const { flags } = await this.parse(HubsEnterpriseListCommand);
-		let queryParams = {};
+		const queryParams = {};
 
 		if (flags.query) {
 			queryParams.query = flags.query;
@@ -19,7 +19,7 @@ class HubsEnterpriseListCommand extends BoxCommand {
 			queryParams.direction = flags.direction;
 		}
 
-		let hubs = await this.markerPagination(
+		const hubs = await this.markerPagination(
 			(pageQueryParams) =>
 				this.tsClient.hubs.getEnterpriseHubsV2025R0(pageQueryParams),
 			queryParams

--- a/src/commands/hubs/get.js
+++ b/src/commands/hubs/get.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const { Args } = require('@oclif/core');
+const BoxCommand = require('../../box-command');
+
+class HubsGetCommand extends BoxCommand {
+	async run() {
+		const { args } = await this.parse(HubsGetCommand);
+		let hub = await this.tsClient.hubs.getHubByIdV2025R0(args.id);
+		delete hub.rawData;
+		await this.output(hub);
+	}
+}
+
+HubsGetCommand.description = 'Get details for a Box Hub';
+HubsGetCommand.examples = ['box hubs:get 12345'];
+HubsGetCommand._endpoint = 'get_hubs_id';
+
+HubsGetCommand.flags = {
+	...BoxCommand.flags,
+};
+
+HubsGetCommand.args = {
+	id: Args.string({
+		name: 'id',
+		required: true,
+		hidden: false,
+		description: 'ID of the Box Hub',
+	}),
+};
+
+module.exports = HubsGetCommand;

--- a/src/commands/hubs/get.js
+++ b/src/commands/hubs/get.js
@@ -6,7 +6,7 @@ const BoxCommand = require('../../box-command');
 class HubsGetCommand extends BoxCommand {
 	async run() {
 		const { args } = await this.parse(HubsGetCommand);
-		let hub = await this.tsClient.hubs.getHubByIdV2025R0(args.id);
+		const hub = await this.tsClient.hubs.getHubByIdV2025R0(args.id);
 		delete hub.rawData;
 		await this.output(hub);
 	}

--- a/src/commands/hubs/index.js
+++ b/src/commands/hubs/index.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const BoxCommand = require('../../box-command');
+const { Flags } = require('@oclif/core');
+const PaginationUtilities = require('../../pagination-utils');
+
+class HubsListCommand extends BoxCommand {
+	async run() {
+		const { flags } = await this.parse(HubsListCommand);
+		let queryParams = {};
+
+		if (flags.query) {
+			queryParams.query = flags.query;
+		}
+		if (flags.scope) {
+			queryParams.scope = flags.scope;
+		}
+		if (flags.sort) {
+			queryParams.sort = flags.sort;
+		}
+		if (flags.direction) {
+			queryParams.direction = flags.direction;
+		}
+
+		let hubs = await this.markerPagination(
+			(pageQueryParams) => this.tsClient.hubs.getHubsV2025R0(pageQueryParams),
+			queryParams
+		);
+		await this.output(hubs);
+	}
+}
+
+HubsListCommand.aliases = ['hubs:list'];
+HubsListCommand.description = 'List Box Hubs for the current user';
+HubsListCommand.examples = [
+	'box hubs',
+	'box hubs --query "Product" --scope editable --sort name --direction ASC',
+];
+HubsListCommand._endpoint = 'get_hubs';
+
+HubsListCommand.flags = {
+	...BoxCommand.flags,
+	...PaginationUtilities.flags,
+	query: Flags.string({
+		description: 'Search query for Box Hubs',
+	}),
+	scope: Flags.string({
+		description:
+			'Scope of hubs to retrieve. One of: editable, view_only, all',
+		options: ['editable', 'view_only', 'all'],
+	}),
+	sort: Flags.string({
+		description:
+			'Sort field for hubs. One of: name, updated_at, last_accessed_at, view_count, relevance',
+		options: [
+			'name',
+			'updated_at',
+			'last_accessed_at',
+			'view_count',
+			'relevance',
+		],
+	}),
+	direction: Flags.string({
+		description: 'Sort direction. One of: ASC, DESC',
+		options: ['ASC', 'DESC'],
+	}),
+};
+
+module.exports = HubsListCommand;

--- a/src/commands/hubs/index.js
+++ b/src/commands/hubs/index.js
@@ -7,7 +7,7 @@ const PaginationUtilities = require('../../pagination-utils');
 class HubsListCommand extends BoxCommand {
 	async run() {
 		const { flags } = await this.parse(HubsListCommand);
-		let queryParams = {};
+		const queryParams = {};
 
 		if (flags.query) {
 			queryParams.query = flags.query;
@@ -22,7 +22,7 @@ class HubsListCommand extends BoxCommand {
 			queryParams.direction = flags.direction;
 		}
 
-		let hubs = await this.markerPagination(
+		const hubs = await this.markerPagination(
 			(pageQueryParams) => this.tsClient.hubs.getHubsV2025R0(pageQueryParams),
 			queryParams
 		);

--- a/src/commands/hubs/update.js
+++ b/src/commands/hubs/update.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const BoxCommand = require('../../box-command');
+const { Flags, Args } = require('@oclif/core');
+const utilities = require('../../util');
+
+class HubsUpdateCommand extends BoxCommand {
+	async run() {
+		const { flags, args } = await this.parse(HubsUpdateCommand);
+		let requestBody = {};
+
+		if (flags.title) {
+			requestBody.title = flags.title;
+		}
+		if (flags.description) {
+			requestBody.description = flags.description;
+		}
+		if (Object.hasOwn(flags, 'ai-enabled')) {
+			requestBody.isAiEnabled = flags['ai-enabled'];
+		}
+		if (Object.hasOwn(flags, 'collaboration-restricted-to-enterprise')) {
+			requestBody.isCollaborationRestrictedToEnterprise =
+				flags['collaboration-restricted-to-enterprise'];
+		}
+		if (Object.hasOwn(flags, 'can-non-owners-invite')) {
+			requestBody.canNonOwnersInvite = flags['can-non-owners-invite'];
+		}
+		if (Object.hasOwn(flags, 'can-shared-link-be-created')) {
+			requestBody.canSharedLinkBeCreated =
+				flags['can-shared-link-be-created'];
+		}
+		if (Object.hasOwn(flags, 'can-public-shared-link-be-created')) {
+			requestBody.canPublicSharedLinkBeCreated =
+				flags['can-public-shared-link-be-created'];
+		}
+
+		if (Object.keys(requestBody).length === 0) {
+			this.error('Please provide at least one update flag.');
+		}
+
+		let hub = await this.tsClient.hubs.updateHubByIdV2025R0(
+			args.id,
+			requestBody
+		);
+		delete hub.rawData;
+		await this.output(hub);
+	}
+}
+
+HubsUpdateCommand.description = 'Update a Box Hub';
+HubsUpdateCommand.examples = [
+	'box hubs:update 12345 --title "Updated title" --ai-enabled',
+];
+HubsUpdateCommand._endpoint = 'put_hubs_id';
+
+HubsUpdateCommand.flags = {
+	...BoxCommand.flags,
+	title: Flags.string({
+		char: 'T',
+		description: 'Updated title for the Box Hub',
+	}),
+	description: Flags.string({
+		char: 'd',
+		description: 'Updated description for the Box Hub',
+		parse: utilities.unescapeSlashes,
+	}),
+	'ai-enabled': Flags.boolean({
+		description: 'Enable or disable AI features for this Box Hub',
+		allowNo: true,
+	}),
+	'collaboration-restricted-to-enterprise': Flags.boolean({
+		description: 'Restrict collaboration to enterprise users only',
+		allowNo: true,
+	}),
+	'can-non-owners-invite': Flags.boolean({
+		description: 'Allow non-owners to invite collaborators',
+		allowNo: true,
+	}),
+	'can-shared-link-be-created': Flags.boolean({
+		description: 'Allow shared links for this Box Hub',
+		allowNo: true,
+	}),
+	'can-public-shared-link-be-created': Flags.boolean({
+		description: 'Allow public shared links for this Box Hub',
+		allowNo: true,
+	}),
+};
+
+HubsUpdateCommand.args = {
+	id: Args.string({
+		name: 'id',
+		required: true,
+		hidden: false,
+		description: 'ID of the Box Hub to update',
+	}),
+};
+
+module.exports = HubsUpdateCommand;

--- a/src/commands/hubs/update.js
+++ b/src/commands/hubs/update.js
@@ -7,7 +7,7 @@ const utilities = require('../../util');
 class HubsUpdateCommand extends BoxCommand {
 	async run() {
 		const { flags, args } = await this.parse(HubsUpdateCommand);
-		let requestBody = {};
+		const requestBody = {};
 
 		if (flags.title) {
 			requestBody.title = flags.title;
@@ -38,7 +38,7 @@ class HubsUpdateCommand extends BoxCommand {
 			this.error('Please provide at least one update flag.');
 		}
 
-		let hub = await this.tsClient.hubs.updateHubByIdV2025R0(
+		const hub = await this.tsClient.hubs.updateHubByIdV2025R0(
 			args.id,
 			requestBody
 		);

--- a/src/commands/tokens/exchange.js
+++ b/src/commands/tokens/exchange.js
@@ -60,7 +60,7 @@ TokensExchangeCommand.flags = {
 		exclusive: ['file-id'],
 	}),
 	token: Flags.string({
-		char: 'T',
+		char: 't',
 		description: 'Specify the token to exchange',
 		exclusive: ['user-id'],
 	}),

--- a/src/commands/tokens/exchange.js
+++ b/src/commands/tokens/exchange.js
@@ -60,7 +60,7 @@ TokensExchangeCommand.flags = {
 		exclusive: ['file-id'],
 	}),
 	token: Flags.string({
-		char: 't',
+		char: 'T',
 		description: 'Specify the token to exchange',
 		exclusive: ['user-id'],
 	}),

--- a/test/commands/hubs.test.js
+++ b/test/commands/hubs.test.js
@@ -1,0 +1,293 @@
+'use strict';
+
+const { test } = require('@oclif/test');
+const { assert } = require('chai');
+const os = require('node:os');
+const { TEST_API_ROOT, getFixture } = require('../helpers/test-helper');
+
+// Hub fixtures use API snake_case fields, but the TS SDK currently returns camelCase JSON output.
+// It also wraps date-time fields in `{ value: ... }` objects, so tests need a normalized expected shape.
+// This is a temporary test helper until a future PR makes command JSON output follow API field naming.
+function formatHubJsonOutput(hub) {
+	return {
+		id: hub.id,
+		type: hub.type,
+		title: hub.title,
+		description: hub.description,
+		createdAt: {
+			value: hub.created_at,
+		},
+		updatedAt: {
+			value: hub.updated_at,
+		},
+		createdBy: hub.created_by,
+		updatedBy: hub.updated_by,
+		viewCount: hub.view_count,
+		isAiEnabled: hub.is_ai_enabled,
+		isCollaborationRestrictedToEnterprise:
+			hub.is_collaboration_restricted_to_enterprise,
+		canNonOwnersInvite: hub.can_non_owners_invite,
+		canSharedLinkBeCreated: hub.can_shared_link_be_created,
+		canPublicSharedLinkBeCreated: hub.can_public_shared_link_be_created,
+	};
+}
+
+describe('Hubs', function () {
+	describe('hubs', function () {
+		const response = {
+			entries: [{ id: '12345', type: 'hubs', title: 'Team Hub' }],
+			limit: 10,
+		};
+
+		test
+			.nock(TEST_API_ROOT, (api) =>
+				api
+					.get('/2.0/hubs')
+					.query({
+						query: 'team',
+						scope: 'editable',
+						sort: 'name',
+						direction: 'ASC',
+						limit: 10,
+					})
+					.reply(200, response)
+			)
+			.stdout()
+			.command([
+				'hubs',
+				'--query=team',
+				'--scope=editable',
+				'--sort=name',
+				'--direction=ASC',
+				'--max-items=10',
+				'--json',
+				'--token=test',
+			])
+			.it('lists hubs with provided filters', (context) => {
+				assert.deepEqual(JSON.parse(context.stdout), [
+					{ id: '12345', type: 'hubs', title: 'Team Hub' },
+				]);
+			});
+
+		const firstPageEntries = Array.from({ length: 1000 }, (_, index) => ({
+			id: `${index + 1}`,
+			type: 'hubs',
+		}));
+		const secondPageEntries = [{ id: '1001', type: 'hubs' }];
+
+		test
+			.nock(TEST_API_ROOT, (api) =>
+				api
+					.get('/2.0/hubs')
+					.query({
+						query: 'team',
+						limit: 1000,
+					})
+					.reply(200, {
+						entries: firstPageEntries,
+						limit: 1000,
+						next_marker: 'next-page',
+					})
+					.get('/2.0/hubs')
+					.query({
+						query: 'team',
+						limit: 1,
+						marker: 'next-page',
+					})
+					.reply(200, {
+						entries: secondPageEntries,
+						limit: 1,
+					})
+			)
+			.stdout()
+			.command([
+				'hubs',
+				'--query=team',
+				'--max-items=1001',
+				'--json',
+				'--token=test',
+			])
+			.it('follows next_marker until max-items is reached', (context) => {
+				const output = JSON.parse(context.stdout);
+				assert.lengthOf(output, 1001);
+				assert.equal(output[0].id, '1');
+				assert.equal(output[1000].id, '1001');
+			});
+	});
+
+	describe('hubs:enterprise', function () {
+		const response = {
+			entries: [{ id: '11111', type: 'hubs', title: 'Enterprise Hub' }],
+			limit: 50,
+		};
+
+		test
+			.nock(TEST_API_ROOT, (api) =>
+				api
+					.get('/2.0/enterprise_hubs')
+					.query({
+						query: 'enterprise',
+						sort: 'updated_at',
+						direction: 'DESC',
+						limit: 50,
+					})
+					.reply(200, response)
+			)
+			.stdout()
+			.command([
+				'hubs:enterprise',
+				'--query=enterprise',
+				'--sort=updated_at',
+				'--direction=DESC',
+				'--max-items=50',
+				'--json',
+				'--token=test',
+			])
+			.it('lists enterprise hubs with provided filters', (context) => {
+				assert.deepEqual(JSON.parse(context.stdout), [
+					{
+						id: '11111',
+						type: 'hubs',
+						title: 'Enterprise Hub',
+					},
+				]);
+			});
+	});
+
+	describe('hubs:get', function () {
+		const response = JSON.parse(getFixture('hubs/get_hubs_id'));
+
+		test
+			.nock(TEST_API_ROOT, (api) =>
+				api.get('/2.0/hubs/12345').reply(200, response)
+			)
+			.stdout()
+			.command(['hubs:get', '12345', '--json', '--token=test'])
+			.it('gets a hub by ID', (context) => {
+				assert.deepEqual(
+					JSON.parse(context.stdout),
+					formatHubJsonOutput(response)
+				);
+			});
+	});
+
+	describe('hubs:create', function () {
+		const response = {
+			id: '98765',
+			type: 'hubs',
+			title: 'New Hub',
+			description: 'New hub description',
+		};
+
+		test
+			.nock(TEST_API_ROOT, (api) =>
+				api
+					.post('/2.0/hubs', {
+						title: 'New Hub',
+						description: 'New hub description',
+					})
+					.reply(200, response)
+			)
+			.stdout()
+			.command([
+				'hubs:create',
+				'New Hub',
+				'--description=New hub description',
+				'--json',
+				'--token=test',
+			])
+			.it('creates a hub with title and description', (context) => {
+				assert.deepEqual(JSON.parse(context.stdout), {
+					id: '98765',
+					type: 'hubs',
+					title: 'New Hub',
+					description: 'New hub description',
+				});
+			});
+	});
+
+	describe('hubs:update', function () {
+		const response = JSON.parse(getFixture('hubs/put_hubs_id'));
+
+		test
+			.nock(TEST_API_ROOT, (api) =>
+				api
+					.put('/2.0/hubs/12345', {
+						title: 'Updated Hub',
+						description: 'Updated description',
+						is_ai_enabled: true,
+						is_collaboration_restricted_to_enterprise: true,
+						can_non_owners_invite: true,
+						can_shared_link_be_created: false,
+					})
+					.reply(200, response)
+			)
+			.stdout()
+			.command([
+				'hubs:update',
+				'12345',
+				'--title=Updated Hub',
+				'--description=Updated description',
+				'--ai-enabled',
+				'--collaboration-restricted-to-enterprise',
+				'--can-non-owners-invite',
+				'--no-can-shared-link-be-created',
+				'--json',
+				'--token=test',
+			])
+			.it('updates a hub with provided fields', (context) => {
+				assert.deepEqual(
+					JSON.parse(context.stdout),
+					formatHubJsonOutput(response)
+				);
+			});
+	});
+
+	describe('hubs:copy', function () {
+		const response = {
+			id: '55555',
+			type: 'hubs',
+			title: 'Copied Hub',
+			description: 'Copied description',
+		};
+
+		test
+			.nock(TEST_API_ROOT, (api) =>
+				api
+					.post('/2.0/hubs/12345/copy', {
+						title: 'Copied Hub',
+						description: 'Copied description',
+					})
+					.reply(200, response)
+			)
+			.stdout()
+			.command([
+				'hubs:copy',
+				'12345',
+				'--title=Copied Hub',
+				'--description=Copied description',
+				'--json',
+				'--token=test',
+			])
+			.it('copies a hub with overrides', (context) => {
+				assert.deepEqual(JSON.parse(context.stdout), {
+					id: '55555',
+					type: 'hubs',
+					title: 'Copied Hub',
+					description: 'Copied description',
+				});
+			});
+	});
+
+	describe('hubs:delete', function () {
+		test
+			.nock(TEST_API_ROOT, (api) =>
+				api.delete('/2.0/hubs/12345').reply(204)
+			)
+			.stderr()
+			.command(['hubs:delete', '12345', '--token=test'])
+			.it('deletes a hub by ID', (context) => {
+				assert.equal(context.stderr, `Deleted hub 12345${os.EOL}`);
+			});
+	});
+});

--- a/test/fixtures/hubs/get_hubs_id.json
+++ b/test/fixtures/hubs/get_hubs_id.json
@@ -1,0 +1,26 @@
+{
+    "id": "12345",
+    "type": "hubs",
+    "title": "Roadmap Hub",
+    "description": "Planning hub for the summer release",
+    "created_at": "2026-02-18T09:12:45.000Z",
+    "updated_at": "2026-04-10T14:28:11.000Z",
+    "created_by": {
+        "id": "11446498",
+        "type": "user",
+        "name": "Aaron Levie",
+        "login": "ceo@example.com"
+    },
+    "updated_by": {
+        "id": "11446498",
+        "type": "user",
+        "name": "Aaron Levie",
+        "login": "ceo@example.com"
+    },
+    "view_count": 12,
+    "is_ai_enabled": true,
+    "is_collaboration_restricted_to_enterprise": false,
+    "can_non_owners_invite": true,
+    "can_shared_link_be_created": true,
+    "can_public_shared_link_be_created": false
+}

--- a/test/fixtures/hubs/put_hubs_id.json
+++ b/test/fixtures/hubs/put_hubs_id.json
@@ -1,0 +1,26 @@
+{
+    "id": "12345",
+    "type": "hubs",
+    "title": "Updated Hub",
+    "description": "Updated description",
+    "created_at": "2026-02-18T09:12:45.000Z",
+    "updated_at": "2026-04-15T17:06:33.000Z",
+    "created_by": {
+        "id": "11446498",
+        "type": "user",
+        "name": "Aaron Levie",
+        "login": "ceo@example.com"
+    },
+    "updated_by": {
+        "id": "11446498",
+        "type": "user",
+        "name": "Aaron Levie",
+        "login": "ceo@example.com"
+    },
+    "view_count": 27,
+    "is_ai_enabled": true,
+    "is_collaboration_restricted_to_enterprise": true,
+    "can_non_owners_invite": true,
+    "can_shared_link_be_created": false,
+    "can_public_shared_link_be_created": true
+}


### PR DESCRIPTION
Added support for Box hubs endpoints:

- https://developer.box.com/reference/v2025.0/get-hubs-id
- https://developer.box.com/reference/v2025.0/get-hubs
- https://developer.box.com/reference/v2025.0/get-enterprise-hubs
- https://developer.box.com/reference/v2025.0/post-hubs-id-copy
- https://developer.box.com/reference/v2025.0/post-hubs
- https://developer.box.com/reference/v2025.0/put-hubs-id
- https://developer.box.com/reference/v2025.0/delete-hubs-id

Added also support for pagination in box-command.js `markerPagination`, as here we have the first endpoint added so far from ts sdk which requires pagination, but it's still not implemented in the sdk.

Additionally, I change in some commands the alias from `-t` to `-T` as this was not working before because of the conflict with the --token flag

