### PR TITLE
feat: Add support for `Box Hub Items` endpoints

### DIFF
--- a/docs/hubs.md
+++ b/docs/hubs.md
@@ -9,6 +9,9 @@ List Box Hubs for the current user
 * [`box hubs:delete ID`](#box-hubsdelete-id)
 * [`box hubs:enterprise`](#box-hubsenterprise)
 * [`box hubs:get ID`](#box-hubsget-id)
+* [`box hubs:items ID`](#box-hubsitems-id)
+* [`box hubs:items:list ID`](#box-hubsitemslist-id)
+* [`box hubs:items:manage ID`](#box-hubsitemsmanage-id)
 * [`box hubs:list`](#box-hubslist)
 * [`box hubs:update ID`](#box-hubsupdate-id)
 
@@ -258,6 +261,142 @@ EXAMPLES
 ```
 
 _See code: [src/commands/hubs/get.js](https://github.com/box/boxcli/blob/v4.7.0/src/commands/hubs/get.js)_
+
+## `box hubs:items ID`
+
+List items in a Box Hub
+
+```
+USAGE
+  $ box hubs:items ID [-t <value>] [--as-user <value>] [--no-color] [--json | --csv] [-s | --save-to-file-path
+    <value>] [--fields <value>] [--bulk-file-path <value>] [-h] [-v] [-y] [-q] [--max-items <value>] [--parent-id
+    <value>]
+
+ARGUMENTS
+  ID  ID of the Box Hub
+
+FLAGS
+  -h, --help                       Show CLI help
+  -q, --quiet                      Suppress any non-error output to stderr
+  -s, --save                       Save report to default reports folder on disk
+  -t, --token=<value>              Provide a token to perform this call
+  -v, --verbose                    Show verbose output, which can be helpful for debugging
+  -y, --yes                        Automatically respond yes to all confirmation prompts
+      --as-user=<value>            Provide an ID for a user
+      --bulk-file-path=<value>     File path to bulk .csv or .json objects
+      --csv                        Output formatted CSV
+      --fields=<value>             Comma separated list of fields to show
+      --json                       Output formatted JSON
+      --max-items=<value>          A value that indicates the maximum number of results to return. This only specifies a
+                                   maximum boundary and will not guarantee the minimum number of results returned. When
+                                   the max-items (x) is greater than 1000, then the maximum ceil(x/1000) requests will
+                                   be made.
+      --no-color                   Turn off colors for logging
+      --parent-id=<value>          Filter to items that belong to a specific item list block in the Box Hub
+      --save-to-file-path=<value>  Override default file path to save report
+
+DESCRIPTION
+  List items in a Box Hub
+
+ALIASES
+  $ box hubs:items:list
+
+EXAMPLES
+  $ box hubs:items 12345
+
+  $ box hubs:items 12345 --parent-id 67890 --max-items 50
+```
+
+_See code: [src/commands/hubs/items/index.js](https://github.com/box/boxcli/blob/v4.7.0/src/commands/hubs/items/index.js)_
+
+## `box hubs:items:list ID`
+
+List items in a Box Hub
+
+```
+USAGE
+  $ box hubs:items:list ID [-t <value>] [--as-user <value>] [--no-color] [--json | --csv] [-s | --save-to-file-path
+    <value>] [--fields <value>] [--bulk-file-path <value>] [-h] [-v] [-y] [-q] [--max-items <value>] [--parent-id
+    <value>]
+
+ARGUMENTS
+  ID  ID of the Box Hub
+
+FLAGS
+  -h, --help                       Show CLI help
+  -q, --quiet                      Suppress any non-error output to stderr
+  -s, --save                       Save report to default reports folder on disk
+  -t, --token=<value>              Provide a token to perform this call
+  -v, --verbose                    Show verbose output, which can be helpful for debugging
+  -y, --yes                        Automatically respond yes to all confirmation prompts
+      --as-user=<value>            Provide an ID for a user
+      --bulk-file-path=<value>     File path to bulk .csv or .json objects
+      --csv                        Output formatted CSV
+      --fields=<value>             Comma separated list of fields to show
+      --json                       Output formatted JSON
+      --max-items=<value>          A value that indicates the maximum number of results to return. This only specifies a
+                                   maximum boundary and will not guarantee the minimum number of results returned. When
+                                   the max-items (x) is greater than 1000, then the maximum ceil(x/1000) requests will
+                                   be made.
+      --no-color                   Turn off colors for logging
+      --parent-id=<value>          Filter to items that belong to a specific item list block in the Box Hub
+      --save-to-file-path=<value>  Override default file path to save report
+
+DESCRIPTION
+  List items in a Box Hub
+
+ALIASES
+  $ box hubs:items:list
+
+EXAMPLES
+  $ box hubs:items 12345
+
+  $ box hubs:items 12345 --parent-id 67890 --max-items 50
+```
+
+## `box hubs:items:manage ID`
+
+Add or remove items in a Box Hub
+
+```
+USAGE
+  $ box hubs:items:manage ID [-t <value>] [--as-user <value>] [--no-color] [--json | --csv] [-s | --save-to-file-path
+    <value>] [--fields <value>] [--bulk-file-path <value>] [-h] [-v] [-y] [-q] [--add <value>...] [--remove <value>...]
+
+ARGUMENTS
+  ID  ID of the Box Hub
+
+FLAGS
+  -h, --help                       Show CLI help
+  -q, --quiet                      Suppress any non-error output to stderr
+  -s, --save                       Save report to default reports folder on disk
+  -t, --token=<value>              Provide a token to perform this call
+  -v, --verbose                    Show verbose output, which can be helpful for debugging
+  -y, --yes                        Automatically respond yes to all confirmation prompts
+      --add=<value>...             Add an item to the Box Hub. Format: id=ITEM_ID,type=TYPE,parent-id=PARENT_ID.
+                                   Supported types are file, folder, web_link. The parent-id is the ID of the parent
+                                   block to add the item to. It must be an Item List block. If not provided, the item
+                                   will be added to the first page's first Item List block.
+      --as-user=<value>            Provide an ID for a user
+      --bulk-file-path=<value>     File path to bulk .csv or .json objects
+      --csv                        Output formatted CSV
+      --fields=<value>             Comma separated list of fields to show
+      --json                       Output formatted JSON
+      --no-color                   Turn off colors for logging
+      --remove=<value>...          Remove an item from the Box Hub. Format: id=ITEM_ID,type=TYPE. Supported types are
+                                   file, folder, web_link.
+      --save-to-file-path=<value>  Override default file path to save report
+
+DESCRIPTION
+  Add or remove items in a Box Hub
+
+EXAMPLES
+  $ box hubs:items:manage 12345 --add id=11111,type=file,parent-id=67890
+
+  $ box hubs:items:manage 12345 --remove id=22222,type=folder
+```
+
+_See code: [src/commands/hubs/items/manage.js](https://github.com/box/boxcli/blob/v4.7.0/src/commands/hubs/items/manage.js)_
 
 ## `box hubs:list`
 

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -13,16 +13,16 @@ Get a token. Returns the service account token by default
 
 ```
 USAGE
-  $ box tokens:exchange SCOPE [--no-color] [-h] [-v] [-q] [-u <value> | -T <value>] [--file-id <value> | --folder-id
+  $ box tokens:exchange SCOPE [--no-color] [-h] [-v] [-q] [-u <value> | -t <value>] [--file-id <value> | --folder-id
     <value>]
 
 ARGUMENTS
   SCOPE  The scope(s) for the new token, separated by a comma if multiple are present
 
 FLAGS
-  -T, --token=<value>      Specify the token to exchange
   -h, --help               Show CLI help
   -q, --quiet              Suppress any non-error output to stderr
+  -t, --token=<value>      Specify the token to exchange
   -u, --user-id=<value>    Get a user token from a user ID
   -v, --verbose            Show verbose output, which can be helpful for debugging
       --file-id=<value>    Scope the token to a specific file

--- a/src/commands/hubs/items/index.js
+++ b/src/commands/hubs/items/index.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const { Args, Flags } = require('@oclif/core');
+const BoxCommand = require('../../../box-command');
+const PaginationUtilities = require('../../../pagination-utils');
+
+class HubsListItemsCommand extends BoxCommand {
+	async run() {
+		const { flags, args } = await this.parse(HubsListItemsCommand);
+		const queryParams = {
+			hubId: args.id,
+		};
+
+		if (flags['parent-id']) {
+			queryParams.parentId = flags['parent-id'];
+		}
+
+		const items = await this.markerPagination(
+			(pageQueryParams) =>
+				this.tsClient.hubItems.getHubItemsV2025R0(pageQueryParams),
+			queryParams
+		);
+		await this.output(items);
+	}
+}
+
+HubsListItemsCommand.aliases = ['hubs:items:list'];
+HubsListItemsCommand.description = 'List items in a Box Hub';
+HubsListItemsCommand.examples = [
+	'box hubs:items 12345',
+	'box hubs:items 12345 --parent-id 67890 --max-items 50',
+];
+HubsListItemsCommand._endpoint = 'get_hub_items';
+
+HubsListItemsCommand.flags = {
+	...BoxCommand.flags,
+	...PaginationUtilities.flags,
+	'parent-id': Flags.string({
+		description:
+			'Filter to items that belong to a specific item list block in the Box Hub',
+	}),
+};
+
+HubsListItemsCommand.args = {
+	id: Args.string({
+		name: 'id',
+		required: true,
+		hidden: false,
+		description: 'ID of the Box Hub',
+	}),
+};
+
+module.exports = HubsListItemsCommand;

--- a/src/commands/hubs/items/manage.js
+++ b/src/commands/hubs/items/manage.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const { Args, Flags } = require('@oclif/core');
+const BoxCommand = require('../../../box-command');
+const utilities = require('../../../util');
+
+const HUB_ITEM_TYPES = ['file', 'folder', 'web_link'];
+const HUB_ITEM_OPERATION_KEYS = ['id', 'type', 'parent-id'];
+
+function parseHubItemOperation(action, input) {
+	const parsed = utilities.parseStringToObject(input, HUB_ITEM_OPERATION_KEYS);
+	const operation = {
+		action,
+		item: {},
+	};
+
+	if (!parsed.id) {
+		throw new Error('Hub item operations require an id key.');
+	}
+
+	if (!parsed.type) {
+		throw new Error('Hub item operations require a type key.');
+	}
+
+	if (!HUB_ITEM_TYPES.includes(parsed.type)) {
+		throw new Error(
+			`Invalid hub item type '${parsed.type}'. Supported types are ${HUB_ITEM_TYPES.join(', ')}.`
+		);
+	}
+
+	operation.item.id = parsed.id;
+	operation.item.type = parsed.type;
+
+	if (parsed['parent-id']) {
+		operation.parentId = parsed['parent-id'];
+	}
+
+	return operation;
+}
+
+class HubsManageItemsCommand extends BoxCommand {
+	async run() {
+		const { flags, args } = await this.parse(HubsManageItemsCommand);
+		const operations = [...(flags.add || []), ...(flags.remove || [])];
+
+		if (operations.length === 0) {
+		throw new Error('Please provide at least one --add or --remove flag.');
+		}
+
+		const response = await this.tsClient.hubItems.manageHubItemsV2025R0(
+			args.id,
+			{ operations }
+		);
+		delete response.rawData;
+		await this.output(response);
+	}
+}
+
+HubsManageItemsCommand.description = 'Add or remove items in a Box Hub';
+HubsManageItemsCommand.examples = [
+	'box hubs:items:manage 12345 --add id=11111,type=file,parent-id=67890',
+	'box hubs:items:manage 12345 --remove id=22222,type=folder',
+];
+HubsManageItemsCommand._endpoint = 'post_hubs_id_manage_items';
+
+HubsManageItemsCommand.flags = {
+	...BoxCommand.flags,
+	add: Flags.string({
+		description:
+			'Add an item to the Box Hub. Format: id=ITEM_ID,type=TYPE,parent-id=PARENT_ID. Supported types are file, folder, web_link. The parent-id is the ID of the parent block to add the item to. It must be an Item List block. If not provided, the item will be added to the first page\'s first Item List block.',
+		multiple: true,
+		parse(input) {
+			return parseHubItemOperation('add', input);
+		},
+	}),
+	remove: Flags.string({
+		description:
+			'Remove an item from the Box Hub. Format: id=ITEM_ID,type=TYPE. Supported types are file, folder, web_link.',
+		multiple: true,
+		parse(input) {
+			return parseHubItemOperation('remove', input);
+		},
+	}),
+};
+
+HubsManageItemsCommand.args = {
+	id: Args.string({
+		name: 'id',
+		required: true,
+		hidden: false,
+		description: 'ID of the Box Hub',
+	}),
+};
+
+module.exports = HubsManageItemsCommand;

--- a/test/commands/hubs.test.js
+++ b/test/commands/hubs.test.js
@@ -154,6 +154,95 @@ describe('Hubs', function () {
 			});
 	});
 
+	describe('hubs:items', function () {
+		const response = JSON.parse(getFixture('hubs/get_hub_items'));
+
+		test
+			.nock(TEST_API_ROOT, (api) =>
+				api
+					.get('/2.0/hub_items')
+					.query({
+						hub_id: '12345',
+						parent_id: '67890',
+						limit: 2,
+					})
+					.reply(200, response)
+			)
+			.stdout()
+			.command([
+				'hubs:items',
+				'12345',
+				'--parent-id=67890',
+				'--max-items=2',
+				'--json',
+				'--token=test',
+			])
+			.it('lists items in a hub', (context) => {
+				assert.deepEqual(JSON.parse(context.stdout), response.entries);
+			});
+	});
+
+	describe('hubs:items:manage', function () {
+		const response = JSON.parse(getFixture('hubs/post_hubs_id_manage_items'));
+
+		test
+			.nock(TEST_API_ROOT, (api) =>
+				api
+					.post('/2.0/hubs/12345/manage_items', {
+						operations: [
+							{
+								action: 'add',
+								item: {
+									id: '11111',
+									type: 'file',
+								},
+								parent_id: '67890',
+							},
+							{
+								action: 'remove',
+								item: {
+									id: '22222',
+									type: 'folder',
+								},
+							},
+						],
+					})
+					.reply(200, response)
+			)
+			.stdout()
+			.command([
+				'hubs:items:manage',
+				'12345',
+				'--add=id=11111,type=file,parent-id=67890',
+				'--remove=id=22222,type=folder',
+				'--json',
+				'--token=test',
+			])
+			.it('adds and removes items in a hub', (context) => {
+				assert.deepEqual(JSON.parse(context.stdout), {
+					operations: [
+						{
+							action: 'add',
+							item: {
+								id: '11111',
+								type: 'file',
+							},
+							parentId: '67890',
+							status: 201,
+						},
+						{
+							action: 'remove',
+							item: {
+								id: '22222',
+								type: 'folder',
+							},
+							status: 204,
+						},
+					],
+				});
+			});
+	});
+
 	describe('hubs:get', function () {
 		const response = JSON.parse(getFixture('hubs/get_hubs_id'));
 

--- a/test/fixtures/hubs/get_hub_items.json
+++ b/test/fixtures/hubs/get_hub_items.json
@@ -1,0 +1,15 @@
+{
+	"entries": [
+		{
+			"id": "11111",
+			"type": "file",
+			"name": "Q2 roadmap.pdf"
+		},
+		{
+			"id": "22222",
+			"type": "folder",
+			"name": "Launch assets"
+		}
+	],
+	"limit": 2
+}

--- a/test/fixtures/hubs/post_hubs_id_manage_items.json
+++ b/test/fixtures/hubs/post_hubs_id_manage_items.json
@@ -1,0 +1,21 @@
+{
+	"operations": [
+		{
+			"action": "add",
+			"item": {
+				"id": "11111",
+				"type": "file"
+			},
+			"parent_id": "67890",
+			"status": 201
+		},
+		{
+			"action": "remove",
+			"item": {
+				"id": "22222",
+				"type": "folder"
+			},
+			"status": 204
+		}
+	]
+}


### PR DESCRIPTION
Added support for two endpoint:
- https://developer.box.com/reference/v2025.0/get-hub-items
- https://developer.box.com/reference/v2025.0/post-hubs-id-manage-items