### PR TITLE
feat: Add support for `Box Hub Collaborations` endpoints

### DIFF
--- a/docs/hubs.md
+++ b/docs/hubs.md
@@ -4,6 +4,13 @@
 List Box Hubs for the current user
 
 * [`box hubs`](#box-hubs)
+* [`box hubs:collaborations ID`](#box-hubscollaborations-id)
+* [`box hubs:collaborations:add ID`](#box-hubscollaborationsadd-id)
+* [`box hubs:collaborations:create ID`](#box-hubscollaborationscreate-id)
+* [`box hubs:collaborations:delete ID`](#box-hubscollaborationsdelete-id)
+* [`box hubs:collaborations:get ID`](#box-hubscollaborationsget-id)
+* [`box hubs:collaborations:list ID`](#box-hubscollaborationslist-id)
+* [`box hubs:collaborations:update ID`](#box-hubscollaborationsupdate-id)
 * [`box hubs:copy ID`](#box-hubscopy-id)
 * [`box hubs:create TITLE`](#box-hubscreate-title)
 * [`box hubs:delete ID`](#box-hubsdelete-id)
@@ -70,6 +77,302 @@ EXAMPLES
 ```
 
 _See code: [src/commands/hubs/index.js](https://github.com/box/boxcli/blob/v4.7.0/src/commands/hubs/index.js)_
+
+## `box hubs:collaborations ID`
+
+List collaborations for a Box Hub
+
+```
+USAGE
+  $ box hubs:collaborations ID [-t <value>] [--as-user <value>] [--no-color] [--json | --csv] [-s | --save-to-file-path
+    <value>] [--fields <value>] [--bulk-file-path <value>] [-h] [-v] [-y] [-q] [--max-items <value>]
+
+ARGUMENTS
+  ID  ID of the Box Hub
+
+FLAGS
+  -h, --help                       Show CLI help
+  -q, --quiet                      Suppress any non-error output to stderr
+  -s, --save                       Save report to default reports folder on disk
+  -t, --token=<value>              Provide a token to perform this call
+  -v, --verbose                    Show verbose output, which can be helpful for debugging
+  -y, --yes                        Automatically respond yes to all confirmation prompts
+      --as-user=<value>            Provide an ID for a user
+      --bulk-file-path=<value>     File path to bulk .csv or .json objects
+      --csv                        Output formatted CSV
+      --fields=<value>             Comma separated list of fields to show
+      --json                       Output formatted JSON
+      --max-items=<value>          A value that indicates the maximum number of results to return. This only specifies a
+                                   maximum boundary and will not guarantee the minimum number of results returned. When
+                                   the max-items (x) is greater than 1000, then the maximum ceil(x/1000) requests will
+                                   be made.
+      --no-color                   Turn off colors for logging
+      --save-to-file-path=<value>  Override default file path to save report
+
+DESCRIPTION
+  List collaborations for a Box Hub
+
+ALIASES
+  $ box hubs:collaborations:list
+
+EXAMPLES
+  $ box hubs:collaborations 12345
+
+  $ box hubs:collaborations 12345 --max-items 50
+```
+
+_See code: [src/commands/hubs/collaborations/index.js](https://github.com/box/boxcli/blob/v4.7.0/src/commands/hubs/collaborations/index.js)_
+
+## `box hubs:collaborations:add ID`
+
+Adds a collaboration with a specific role for a single user or a single group to a Box Hub. Collaborations can be created using email address, user IDs, or group IDs
+
+```
+USAGE
+  $ box hubs:collaborations:add ID -r editor|viewer|co-owner [-t <value>] [--as-user <value>] [--no-color] [--json | --csv]
+    [-s | --save-to-file-path <value>] [--fields <value>] [--bulk-file-path <value>] [-h] [-v] [-y] [-q] [--user-id
+    <value> | --group-id <value> | --login <value>]
+
+ARGUMENTS
+  ID  ID of the Box Hub
+
+FLAGS
+  -h, --help                       Show CLI help
+  -q, --quiet                      Suppress any non-error output to stderr
+  -r, --role=<option>              (required) Role to grant for the hub collaboration. One of: editor, viewer, co-owner
+                                   <options: editor|viewer|co-owner>
+  -s, --save                       Save report to default reports folder on disk
+  -t, --token=<value>              Provide a token to perform this call
+  -v, --verbose                    Show verbose output, which can be helpful for debugging
+  -y, --yes                        Automatically respond yes to all confirmation prompts
+      --as-user=<value>            Provide an ID for a user
+      --bulk-file-path=<value>     File path to bulk .csv or .json objects
+      --csv                        Output formatted CSV
+      --fields=<value>             Comma separated list of fields to show
+      --group-id=<value>           Collaborate a group by Box group ID
+      --json                       Output formatted JSON
+      --login=<value>              Collaborate a user by email address
+      --no-color                   Turn off colors for logging
+      --save-to-file-path=<value>  Override default file path to save report
+      --user-id=<value>            Collaborate a user by Box user ID
+
+DESCRIPTION
+  Adds a collaboration with a specific role for a single user or a single group to a Box Hub. Collaborations can be
+  created using email address, user IDs, or group IDs
+
+ALIASES
+  $ box hubs:collaborations:add
+
+EXAMPLES
+  $ box hubs:collaborations:create 12345 --role editor --user-id 22222
+
+  $ box hubs:collaborations:create 12345 --role viewer --group-id 33333
+
+  $ box hubs:collaborations:create 12345 --role co-owner --login jdoe@example.com
+```
+
+## `box hubs:collaborations:create ID`
+
+Adds a collaboration with a specific role for a single user or a single group to a Box Hub. Collaborations can be created using email address, user IDs, or group IDs
+
+```
+USAGE
+  $ box hubs:collaborations:create ID -r editor|viewer|co-owner [-t <value>] [--as-user <value>] [--no-color] [--json | --csv]
+    [-s | --save-to-file-path <value>] [--fields <value>] [--bulk-file-path <value>] [-h] [-v] [-y] [-q] [--user-id
+    <value> | --group-id <value> | --login <value>]
+
+ARGUMENTS
+  ID  ID of the Box Hub
+
+FLAGS
+  -h, --help                       Show CLI help
+  -q, --quiet                      Suppress any non-error output to stderr
+  -r, --role=<option>              (required) Role to grant for the hub collaboration. One of: editor, viewer, co-owner
+                                   <options: editor|viewer|co-owner>
+  -s, --save                       Save report to default reports folder on disk
+  -t, --token=<value>              Provide a token to perform this call
+  -v, --verbose                    Show verbose output, which can be helpful for debugging
+  -y, --yes                        Automatically respond yes to all confirmation prompts
+      --as-user=<value>            Provide an ID for a user
+      --bulk-file-path=<value>     File path to bulk .csv or .json objects
+      --csv                        Output formatted CSV
+      --fields=<value>             Comma separated list of fields to show
+      --group-id=<value>           Collaborate a group by Box group ID
+      --json                       Output formatted JSON
+      --login=<value>              Collaborate a user by email address
+      --no-color                   Turn off colors for logging
+      --save-to-file-path=<value>  Override default file path to save report
+      --user-id=<value>            Collaborate a user by Box user ID
+
+DESCRIPTION
+  Adds a collaboration with a specific role for a single user or a single group to a Box Hub. Collaborations can be
+  created using email address, user IDs, or group IDs
+
+ALIASES
+  $ box hubs:collaborations:add
+
+EXAMPLES
+  $ box hubs:collaborations:create 12345 --role editor --user-id 22222
+
+  $ box hubs:collaborations:create 12345 --role viewer --group-id 33333
+
+  $ box hubs:collaborations:create 12345 --role co-owner --login jdoe@example.com
+```
+
+_See code: [src/commands/hubs/collaborations/create.js](https://github.com/box/boxcli/blob/v4.7.0/src/commands/hubs/collaborations/create.js)_
+
+## `box hubs:collaborations:delete ID`
+
+Delete a single Box Hub collaboration
+
+```
+USAGE
+  $ box hubs:collaborations:delete ID [-t <value>] [--as-user <value>] [--no-color] [--json | --csv] [-s | --save-to-file-path
+    <value>] [--fields <value>] [--bulk-file-path <value>] [-h] [-v] [-y] [-q]
+
+ARGUMENTS
+  ID  ID of the hub collaboration to delete
+
+FLAGS
+  -h, --help                       Show CLI help
+  -q, --quiet                      Suppress any non-error output to stderr
+  -s, --save                       Save report to default reports folder on disk
+  -t, --token=<value>              Provide a token to perform this call
+  -v, --verbose                    Show verbose output, which can be helpful for debugging
+  -y, --yes                        Automatically respond yes to all confirmation prompts
+      --as-user=<value>            Provide an ID for a user
+      --bulk-file-path=<value>     File path to bulk .csv or .json objects
+      --csv                        Output formatted CSV
+      --fields=<value>             Comma separated list of fields to show
+      --json                       Output formatted JSON
+      --no-color                   Turn off colors for logging
+      --save-to-file-path=<value>  Override default file path to save report
+
+DESCRIPTION
+  Delete a single Box Hub collaboration
+
+EXAMPLES
+  $ box hubs:collaborations:delete 99999
+```
+
+_See code: [src/commands/hubs/collaborations/delete.js](https://github.com/box/boxcli/blob/v4.7.0/src/commands/hubs/collaborations/delete.js)_
+
+## `box hubs:collaborations:get ID`
+
+Retrieves details for a Box Hub collaboration by collaboration ID
+
+```
+USAGE
+  $ box hubs:collaborations:get ID [-t <value>] [--as-user <value>] [--no-color] [--json | --csv] [-s | --save-to-file-path
+    <value>] [--fields <value>] [--bulk-file-path <value>] [-h] [-v] [-y] [-q]
+
+ARGUMENTS
+  ID  ID of the hub collaboration
+
+FLAGS
+  -h, --help                       Show CLI help
+  -q, --quiet                      Suppress any non-error output to stderr
+  -s, --save                       Save report to default reports folder on disk
+  -t, --token=<value>              Provide a token to perform this call
+  -v, --verbose                    Show verbose output, which can be helpful for debugging
+  -y, --yes                        Automatically respond yes to all confirmation prompts
+      --as-user=<value>            Provide an ID for a user
+      --bulk-file-path=<value>     File path to bulk .csv or .json objects
+      --csv                        Output formatted CSV
+      --fields=<value>             Comma separated list of fields to show
+      --json                       Output formatted JSON
+      --no-color                   Turn off colors for logging
+      --save-to-file-path=<value>  Override default file path to save report
+
+DESCRIPTION
+  Retrieves details for a Box Hub collaboration by collaboration ID
+
+EXAMPLES
+  $ box hubs:collaborations:get 99999
+```
+
+_See code: [src/commands/hubs/collaborations/get.js](https://github.com/box/boxcli/blob/v4.7.0/src/commands/hubs/collaborations/get.js)_
+
+## `box hubs:collaborations:list ID`
+
+List collaborations for a Box Hub
+
+```
+USAGE
+  $ box hubs:collaborations:list ID [-t <value>] [--as-user <value>] [--no-color] [--json | --csv] [-s | --save-to-file-path
+    <value>] [--fields <value>] [--bulk-file-path <value>] [-h] [-v] [-y] [-q] [--max-items <value>]
+
+ARGUMENTS
+  ID  ID of the Box Hub
+
+FLAGS
+  -h, --help                       Show CLI help
+  -q, --quiet                      Suppress any non-error output to stderr
+  -s, --save                       Save report to default reports folder on disk
+  -t, --token=<value>              Provide a token to perform this call
+  -v, --verbose                    Show verbose output, which can be helpful for debugging
+  -y, --yes                        Automatically respond yes to all confirmation prompts
+      --as-user=<value>            Provide an ID for a user
+      --bulk-file-path=<value>     File path to bulk .csv or .json objects
+      --csv                        Output formatted CSV
+      --fields=<value>             Comma separated list of fields to show
+      --json                       Output formatted JSON
+      --max-items=<value>          A value that indicates the maximum number of results to return. This only specifies a
+                                   maximum boundary and will not guarantee the minimum number of results returned. When
+                                   the max-items (x) is greater than 1000, then the maximum ceil(x/1000) requests will
+                                   be made.
+      --no-color                   Turn off colors for logging
+      --save-to-file-path=<value>  Override default file path to save report
+
+DESCRIPTION
+  List collaborations for a Box Hub
+
+ALIASES
+  $ box hubs:collaborations:list
+
+EXAMPLES
+  $ box hubs:collaborations 12345
+
+  $ box hubs:collaborations 12345 --max-items 50
+```
+
+## `box hubs:collaborations:update ID`
+
+Updates a Box Hub collaboration. Can be used to change the Box Hub role.
+
+```
+USAGE
+  $ box hubs:collaborations:update ID -r editor|viewer|co-owner [-t <value>] [--as-user <value>] [--no-color] [--json | --csv]
+    [-s | --save-to-file-path <value>] [--fields <value>] [--bulk-file-path <value>] [-h] [-v] [-y] [-q]
+
+ARGUMENTS
+  ID  ID of the hub collaboration to update
+
+FLAGS
+  -h, --help                       Show CLI help
+  -q, --quiet                      Suppress any non-error output to stderr
+  -r, --role=<option>              (required) Updated role for the hub collaboration. One of: editor, viewer, co-owner
+                                   <options: editor|viewer|co-owner>
+  -s, --save                       Save report to default reports folder on disk
+  -t, --token=<value>              Provide a token to perform this call
+  -v, --verbose                    Show verbose output, which can be helpful for debugging
+  -y, --yes                        Automatically respond yes to all confirmation prompts
+      --as-user=<value>            Provide an ID for a user
+      --bulk-file-path=<value>     File path to bulk .csv or .json objects
+      --csv                        Output formatted CSV
+      --fields=<value>             Comma separated list of fields to show
+      --json                       Output formatted JSON
+      --no-color                   Turn off colors for logging
+      --save-to-file-path=<value>  Override default file path to save report
+
+DESCRIPTION
+  Updates a Box Hub collaboration. Can be used to change the Box Hub role.
+
+EXAMPLES
+  $ box hubs:collaborations:update 99999 --role viewer
+```
+
+_See code: [src/commands/hubs/collaborations/update.js](https://github.com/box/boxcli/blob/v4.7.0/src/commands/hubs/collaborations/update.js)_
 
 ## `box hubs:copy ID`
 

--- a/src/commands/hubs/collaborations/create.js
+++ b/src/commands/hubs/collaborations/create.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const { Args, Flags } = require('@oclif/core');
+const BoxCommand = require('../../../box-command');
+
+const HUB_COLLABORATION_ROLES = ['editor', 'viewer', 'co-owner'];
+
+function getAccessibleBy(flags) {
+	if (flags['user-id']) {
+		return {
+			type: 'user',
+			id: flags['user-id'],
+		};
+	}
+
+	if (flags['group-id']) {
+		return {
+			type: 'group',
+			id: flags['group-id'],
+		};
+	}
+
+	if (flags.login) {
+		return {
+			type: 'user',
+			login: flags.login,
+		};
+	}
+
+	throw new Error('Please provide one of --user-id, --group-id, or --login.');
+}
+
+class HubsCreateCollaborationCommand extends BoxCommand {
+	async run() {
+		const { flags, args } = await this.parse(HubsCreateCollaborationCommand);
+		const requestBody = {
+			hub: {
+				id: args.id,
+				type: 'hubs',
+			},
+			accessibleBy: getAccessibleBy(flags),
+			role: flags.role,
+		};
+
+		const collaboration =
+			await this.tsClient.hubCollaborations.createHubCollaborationV2025R0(
+				requestBody
+			);
+		delete collaboration.rawData;
+		await this.output(collaboration);
+	}
+}
+HubsCreateCollaborationCommand.aliases = ['hubs:collaborations:add'];
+HubsCreateCollaborationCommand.description =
+	'Adds a collaboration with a specific role for a single user or a single group to a Box Hub. Collaborations can be created using email address, user IDs, or group IDs';
+HubsCreateCollaborationCommand.examples = [
+	'box hubs:collaborations:create 12345 --role editor --user-id 22222',
+	'box hubs:collaborations:create 12345 --role viewer --group-id 33333',
+	'box hubs:collaborations:create 12345 --role co-owner --login jdoe@example.com',
+];
+HubsCreateCollaborationCommand._endpoint = 'post_hub_collaborations';
+
+HubsCreateCollaborationCommand.flags = {
+	...BoxCommand.flags,
+	role: Flags.string({
+		char: 'r',
+		description:
+			'Role to grant for the hub collaboration. One of: editor, viewer, co-owner',
+		required: true,
+		options: HUB_COLLABORATION_ROLES,
+	}),
+	'user-id': Flags.string({
+		description: 'Collaborate a user by Box user ID',
+		exclusive: ['group-id', 'login'],
+	}),
+	'group-id': Flags.string({
+		description: 'Collaborate a group by Box group ID',
+		exclusive: ['user-id', 'login'],
+	}),
+	login: Flags.string({
+		description: 'Collaborate a user by email address',
+		exclusive: ['user-id', 'group-id'],
+	}),
+};
+
+HubsCreateCollaborationCommand.args = {
+	id: Args.string({
+		name: 'id',
+		required: true,
+		hidden: false,
+		description: 'ID of the Box Hub',
+	}),
+};
+
+module.exports = HubsCreateCollaborationCommand;

--- a/src/commands/hubs/collaborations/delete.js
+++ b/src/commands/hubs/collaborations/delete.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const { Args } = require('@oclif/core');
+const BoxCommand = require('../../../box-command');
+
+class HubsDeleteCollaborationCommand extends BoxCommand {
+	async run() {
+		const { args } = await this.parse(HubsDeleteCollaborationCommand);
+		await this.tsClient.hubCollaborations.deleteHubCollaborationByIdV2025R0(
+			args.id
+		);
+		this.info(`Deleted hub collaboration ${args.id}`);
+	}
+}
+
+HubsDeleteCollaborationCommand.description = 'Delete a single Box Hub collaboration';
+HubsDeleteCollaborationCommand.examples = [
+	'box hubs:collaborations:delete 99999',
+];
+HubsDeleteCollaborationCommand._endpoint = 'delete_hub_collaborations_id';
+
+HubsDeleteCollaborationCommand.flags = {
+	...BoxCommand.flags,
+};
+
+HubsDeleteCollaborationCommand.args = {
+	id: Args.string({
+		name: 'id',
+		required: true,
+		hidden: false,
+		description: 'ID of the hub collaboration to delete',
+	}),
+};
+
+module.exports = HubsDeleteCollaborationCommand;

--- a/src/commands/hubs/collaborations/get.js
+++ b/src/commands/hubs/collaborations/get.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const { Args } = require('@oclif/core');
+const BoxCommand = require('../../../box-command');
+
+class HubsGetCollaborationCommand extends BoxCommand {
+	async run() {
+		const { args } = await this.parse(HubsGetCollaborationCommand);
+		const collaboration =
+			await this.tsClient.hubCollaborations.getHubCollaborationByIdV2025R0(
+				args.id
+			);
+		delete collaboration.rawData;
+		await this.output(collaboration);
+	}
+}
+
+HubsGetCollaborationCommand.description =
+	'Retrieves details for a Box Hub collaboration by collaboration ID';
+HubsGetCollaborationCommand.examples = ['box hubs:collaborations:get 99999'];
+HubsGetCollaborationCommand._endpoint = 'get_hub_collaborations_id';
+
+HubsGetCollaborationCommand.flags = {
+	...BoxCommand.flags,
+};
+
+HubsGetCollaborationCommand.args = {
+	id: Args.string({
+		name: 'id',
+		required: true,
+		hidden: false,
+		description: 'ID of the hub collaboration',
+	}),
+};
+
+module.exports = HubsGetCollaborationCommand;

--- a/src/commands/hubs/collaborations/index.js
+++ b/src/commands/hubs/collaborations/index.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const { Args } = require('@oclif/core');
+const BoxCommand = require('../../../box-command');
+const PaginationUtilities = require('../../../pagination-utils');
+
+class HubsListCollaborationsCommand extends BoxCommand {
+	async run() {
+		const { args } = await this.parse(HubsListCollaborationsCommand);
+		const queryParams = {
+			hubId: args.id,
+		};
+
+		const collaborations = await this.markerPagination(
+			(pageQueryParams) =>
+				this.tsClient.hubCollaborations.getHubCollaborationsV2025R0(
+					pageQueryParams
+				),
+			queryParams
+		);
+		await this.output(collaborations);
+	}
+}
+
+HubsListCollaborationsCommand.aliases = ['hubs:collaborations:list'];
+HubsListCollaborationsCommand.description = 'List collaborations for a Box Hub';
+HubsListCollaborationsCommand.examples = [
+	'box hubs:collaborations 12345',
+	'box hubs:collaborations 12345 --max-items 50',
+];
+HubsListCollaborationsCommand._endpoint = 'get_hub_collaborations';
+
+HubsListCollaborationsCommand.flags = {
+	...BoxCommand.flags,
+	...PaginationUtilities.flags,
+};
+
+HubsListCollaborationsCommand.args = {
+	id: Args.string({
+		name: 'id',
+		required: true,
+		hidden: false,
+		description: 'ID of the Box Hub',
+	}),
+};
+
+module.exports = HubsListCollaborationsCommand;

--- a/src/commands/hubs/collaborations/update.js
+++ b/src/commands/hubs/collaborations/update.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const { Args, Flags } = require('@oclif/core');
+const BoxCommand = require('../../../box-command');
+
+const HUB_COLLABORATION_ROLES = ['editor', 'viewer', 'co-owner'];
+
+class HubsUpdateCollaborationCommand extends BoxCommand {
+	async run() {
+		const { flags, args } = await this.parse(HubsUpdateCollaborationCommand);
+		const collaboration =
+			await this.tsClient.hubCollaborations.updateHubCollaborationByIdV2025R0(
+				args.id,
+				{
+					role: flags.role,
+				}
+			);
+		delete collaboration.rawData;
+		await this.output(collaboration);
+	}
+}
+
+HubsUpdateCollaborationCommand.description = 'Updates a Box Hub collaboration. Can be used to change the Box Hub role.';
+HubsUpdateCollaborationCommand.examples = [
+	'box hubs:collaborations:update 99999 --role viewer',
+];
+HubsUpdateCollaborationCommand._endpoint = 'put_hub_collaborations_id';
+
+HubsUpdateCollaborationCommand.flags = {
+	...BoxCommand.flags,
+	role: Flags.string({
+		char: 'r',
+		description:
+			'Updated role for the hub collaboration. One of: editor, viewer, co-owner',
+		required: true,
+		options: HUB_COLLABORATION_ROLES,
+	}),
+};
+
+HubsUpdateCollaborationCommand.args = {
+	id: Args.string({
+		name: 'id',
+		required: true,
+		hidden: false,
+		description: 'ID of the hub collaboration to update',
+	}),
+};
+
+module.exports = HubsUpdateCollaborationCommand;

--- a/test/commands/hubs.test.js
+++ b/test/commands/hubs.test.js
@@ -32,6 +32,43 @@ function formatHubJsonOutput(hub) {
 	};
 }
 
+function formatHubCollaborationGrantee(grantee) {
+	const output = {
+		id: grantee.id,
+		type: grantee.type,
+	};
+
+	if (grantee.name) {
+		output.name = grantee.name;
+	}
+	if (grantee.login) {
+		output.login = grantee.login;
+	}
+	if (grantee.group_type) {
+		output.groupType = grantee.group_type;
+	}
+
+	return output;
+}
+
+function formatHubCollaborationJsonOutput(collaboration) {
+	const output = {
+		id: collaboration.id,
+		type: collaboration.type,
+		hub: collaboration.hub,
+		role: collaboration.role,
+		status: collaboration.status,
+	};
+
+	if (collaboration.accessible_by) {
+		output.accessibleBy = formatHubCollaborationGrantee(
+			collaboration.accessible_by
+		);
+	}
+
+	return output;
+}
+
 describe('Hubs', function () {
 	describe('hubs', function () {
 		const response = {
@@ -455,6 +492,169 @@ describe('Hubs', function () {
 			.command(['hubs:delete', '12345', '--token=test'])
 			.it('deletes a hub by ID', (context) => {
 				assert.equal(context.stderr, `Deleted hub 12345${os.EOL}`);
+			});
+	});
+
+	describe('hubs:collaborations', function () {
+		const response = JSON.parse(getFixture('hubs/get_hub_collaborations'));
+
+		test
+			.nock(TEST_API_ROOT, (api) =>
+				api
+					.get('/2.0/hub_collaborations')
+					.query({
+						hub_id: '12345',
+						limit: 1,
+					})
+					.reply(200, response)
+			)
+			.stdout()
+			.command([
+				'hubs:collaborations',
+				'12345',
+				'--max-items=1',
+				'--json',
+				'--token=test',
+			])
+			.it('lists collaborations for a hub', (context) => {
+				assert.deepEqual(JSON.parse(context.stdout), [
+					formatHubCollaborationJsonOutput(response.entries[0]),
+				]);
+			});
+	});
+
+	describe('hubs:collaborations:create', function () {
+		const response = JSON.parse(getFixture('hubs/post_hub_collaborations'));
+
+		test
+			.nock(TEST_API_ROOT, (api) =>
+				api
+					.post('/2.0/hub_collaborations', {
+						hub: {
+							id: '12345',
+							type: 'hubs',
+						},
+						accessible_by: {
+							type: 'user',
+							id: '22222',
+						},
+						role: 'editor',
+					})
+					.reply(200, response)
+			)
+			.stdout()
+			.command([
+				'hubs:collaborations:create',
+				'12345',
+				'--role=editor',
+				'--user-id=22222',
+				'--json',
+				'--token=test',
+			])
+			.it('creates a collaboration for a hub', (context) => {
+				assert.deepEqual(
+					JSON.parse(context.stdout),
+					formatHubCollaborationJsonOutput(response)
+				);
+			});
+
+		it('rejects unsupported hub collaboration roles on create', async function () {
+			return test
+				.command([
+					'hubs:collaborations:create',
+					'12345',
+					'--role=owner',
+					'--user-id=22222',
+					'--token=test',
+				])
+				.catch((error) => {
+					assert.include(
+						error.message,
+						'Expected --role=owner to be one of: editor, viewer, co-owner'
+					);
+				});
+		});
+	});
+
+	describe('hubs:collaborations:get', function () {
+		const response = JSON.parse(getFixture('hubs/get_hub_collaborations_id'));
+
+		test
+			.nock(TEST_API_ROOT, (api) =>
+				api.get('/2.0/hub_collaborations/99999').reply(200, response)
+			)
+			.stdout()
+			.command([
+				'hubs:collaborations:get',
+				'99999',
+				'--json',
+				'--token=test',
+			])
+			.it('gets a hub collaboration by ID', (context) => {
+				assert.deepEqual(
+					JSON.parse(context.stdout),
+					formatHubCollaborationJsonOutput(response)
+				);
+			});
+	});
+
+	describe('hubs:collaborations:update', function () {
+		const response = JSON.parse(
+			getFixture('hubs/put_hub_collaborations_id')
+		);
+
+		test
+			.nock(TEST_API_ROOT, (api) =>
+				api
+					.put('/2.0/hub_collaborations/99999', {
+						role: 'viewer',
+					})
+					.reply(200, response)
+			)
+			.stdout()
+			.command([
+				'hubs:collaborations:update',
+				'99999',
+				'--role=viewer',
+				'--json',
+				'--token=test',
+			])
+			.it('updates a hub collaboration role', (context) => {
+				assert.deepEqual(
+					JSON.parse(context.stdout),
+					formatHubCollaborationJsonOutput(response)
+				);
+			});
+
+		it('rejects unsupported hub collaboration roles on update', async function () {
+			return test
+				.command([
+					'hubs:collaborations:update',
+					'99999',
+					'--role=owner',
+					'--token=test',
+				])
+				.catch((error) => {
+					assert.include(
+						error.message,
+						'Expected --role=owner to be one of: editor, viewer, co-owner'
+					);
+				});
+		});
+	});
+
+	describe('hubs:collaborations:delete', function () {
+		test
+			.nock(TEST_API_ROOT, (api) =>
+				api.delete('/2.0/hub_collaborations/99999').reply(204)
+			)
+			.stderr()
+			.command(['hubs:collaborations:delete', '99999', '--token=test'])
+			.it('deletes a hub collaboration by ID', (context) => {
+				assert.equal(
+					context.stderr,
+					`Deleted hub collaboration 99999${os.EOL}`
+				);
 			});
 	});
 });

--- a/test/fixtures/hubs/get_hub_collaborations.json
+++ b/test/fixtures/hubs/get_hub_collaborations.json
@@ -1,0 +1,21 @@
+{
+	"entries": [
+		{
+			"id": "99999",
+			"type": "hub_collaboration",
+			"hub": {
+				"id": "12345",
+				"type": "hubs"
+			},
+			"accessible_by": {
+				"id": "22222",
+				"type": "user",
+				"name": "Editor Example",
+				"login": "editor@example.com"
+			},
+			"role": "editor",
+			"status": "accepted"
+		}
+	],
+	"limit": 1
+}

--- a/test/fixtures/hubs/get_hub_collaborations_id.json
+++ b/test/fixtures/hubs/get_hub_collaborations_id.json
@@ -1,0 +1,16 @@
+{
+	"id": "99999",
+	"type": "hub_collaboration",
+	"hub": {
+		"id": "12345",
+		"type": "hubs"
+	},
+	"accessible_by": {
+		"id": "22222",
+		"type": "user",
+		"name": "Editor Example",
+		"login": "editor@example.com"
+	},
+	"role": "editor",
+	"status": "accepted"
+}

--- a/test/fixtures/hubs/post_hub_collaborations.json
+++ b/test/fixtures/hubs/post_hub_collaborations.json
@@ -1,0 +1,16 @@
+{
+	"id": "99999",
+	"type": "hub_collaboration",
+	"hub": {
+		"id": "12345",
+		"type": "hubs"
+	},
+	"accessible_by": {
+		"id": "22222",
+		"type": "user",
+		"name": "Editor Example",
+		"login": "editor@example.com"
+	},
+	"role": "editor",
+	"status": "accepted"
+}

--- a/test/fixtures/hubs/put_hub_collaborations_id.json
+++ b/test/fixtures/hubs/put_hub_collaborations_id.json
@@ -1,0 +1,16 @@
+{
+	"id": "99999",
+	"type": "hub_collaboration",
+	"hub": {
+		"id": "12345",
+		"type": "hubs"
+	},
+	"accessible_by": {
+		"id": "22222",
+		"type": "user",
+		"name": "Editor Example",
+		"login": "editor@example.com"
+	},
+	"role": "viewer",
+	"status": "accepted"
+}


### PR DESCRIPTION
Added support for Box Hubs Collaborations endpoints:

- https://developer.box.com/reference/v2025.0/get-hub-collaborations-id
- https://developer.box.com/reference/v2025.0/get-hub-collaborations
- https://developer.box.com/reference/v2025.0/post-hub-collaborations
- https://developer.box.com/reference/v2025.0/put-hub-collaborations-id
- https://developer.box.com/reference/v2025.0/delete-hub-collaborations-id