### PR TITLE
fix: Fix `deprovision` script when `AsUserHeader` is empty

### DIFF
--- a/examples/User Deprovisioning/Users_Deprovision.ps1
+++ b/examples/User Deprovisioning/Users_Deprovision.ps1
@@ -254,7 +254,7 @@ Function Start-Deprovisioning-Script {
         }
 
         # Validate new files owner if is not current user
-        $AsUserHeader = ""
+        $AsUserHeader = $null
         if ($NewFilesOwnerID -and ($NewFilesOwnerID -ne $CurrentUserId)) {
             Write-Log "Validating new files owner exists" -output true -color Yellow
             try {


### PR DESCRIPTION
Omit AsUserHeader in the cli call when empty by using null instead of empty string