### PR TITLE
ci: notify `npm-box` on new CLI release

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -29,3 +29,11 @@ jobs:
           repository: box/box-developer-changelog
           event-type: new-release-note
           client-payload: '{"ref": "${{ github.ref }}", "repository": "${{github.repository}}", "labels": "cli", "repo_display_name": "Box CLI"}'
+
+      - name: Notify npm-box of new release
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
+          repository: box/npm-box
+          event-type: cli-release
+          client-payload: '{"version": "${{ github.event.release.tag_name }}", "repository": "${{ github.repository }}"}'


### PR DESCRIPTION
## Summary
- Adds a `repository_dispatch` step to the release workflow that notifies `box/npm-box` when a new CLI version is released
- This triggers npm-box to auto-bump its `@box/cli` dependency and open a PR

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Confirm dispatch fires on next release (or test with `gh api`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)